### PR TITLE
Introduce Planning thresholds and feature-promotion recommendation in PlanningAgentService

### DIFF
--- a/src/AIAgents.Core/Configuration/PlanningOptions.cs
+++ b/src/AIAgents.Core/Configuration/PlanningOptions.cs
@@ -1,0 +1,20 @@
+namespace AIAgents.Core.Configuration;
+
+/// <summary>
+/// Configuration for Planning agent workflow behavior.
+/// Bound to the "Planning" configuration section.
+/// </summary>
+public sealed class PlanningOptions
+{
+    public const string SectionName = "Planning";
+
+    /// <summary>
+    /// Complexity threshold above which a User Story should be promoted to a Feature.
+    /// </summary>
+    public int FeaturePromotionComplexityThreshold { get; init; } = 13;
+
+    /// <summary>
+    /// Sub-task threshold above which a User Story should be promoted to a Feature.
+    /// </summary>
+    public int FeaturePromotionSubstoryThreshold { get; init; } = 8;
+}

--- a/src/AIAgents.Functions.Tests/Agents/PlanningAgentServiceTests.cs
+++ b/src/AIAgents.Functions.Tests/Agents/PlanningAgentServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using AIAgents.Core.Configuration;
 using AIAgents.Core.Constants;
 using AIAgents.Core.Interfaces;
 using AIAgents.Core.Models;
@@ -45,7 +46,7 @@ public sealed class PlanningAgentServiceTests
         _contextFactoryMock.Setup(f => f.Create(It.IsAny<int>(), It.IsAny<string>())).Returns(_contextMock.Object);
     }
 
-    private PlanningAgentService CreateService()
+    private PlanningAgentService CreateService(PlanningOptions? planningOptions = null)
     {
         return new PlanningAgentService(
             _aiFactoryMock.Object,
@@ -55,7 +56,8 @@ public sealed class PlanningAgentServiceTests
             _templateMock.Object,
             _codebaseMock.Object,
             NullLogger<PlanningAgentService>.Instance,
-            _taskQueueMock.Object);
+            _taskQueueMock.Object,
+            planningOptions is null ? null : Microsoft.Extensions.Options.Options.Create(planningOptions));
     }
 
     private void SetupHappyPath(StoryWorkItem? workItem = null, string? aiResponse = null)
@@ -388,6 +390,50 @@ public sealed class PlanningAgentServiceTests
 
         Assert.Contains(_capturedState.Decisions, d =>
             d.Agent == "Planning" && d.DecisionText.Contains("rejected by triage gate"));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_OversizedStory_PostsPromotionRecommendationAndMovesToNeedsRevision()
+    {
+        SetupHappyPath(aiResponse: MockAIResponses.OversizedPlanningResponse);
+        var service = CreateService(new PlanningOptions
+        {
+            FeaturePromotionComplexityThreshold = 8,
+            FeaturePromotionSubstoryThreshold = 6
+        });
+        var task = new AgentTask { WorkItemId = 12345, AgentType = AgentType.Planning };
+
+        await service.ExecuteAsync(task);
+
+        Assert.Equal("Needs Revision", _capturedState.CurrentState);
+        _adoMock.Verify(a => a.AddWorkItemCommentAsync(12345,
+            It.Is<string>(c => c.Contains("Promote User Story to Feature") &&
+                              c.Contains("Suggested Decomposition")),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _adoMock.Verify(a => a.UpdateWorkItemStateAsync(12345, "Needs Revision", It.IsAny<CancellationToken>()), Times.Once);
+        _taskQueueMock.Verify(q => q.EnqueueAsync(It.IsAny<AgentTask>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BelowPromotionThreshold_ProceedsToCoding()
+    {
+        SetupHappyPath(aiResponse: MockAIResponses.ValidPlanningResponse);
+        var service = CreateService(new PlanningOptions
+        {
+            FeaturePromotionComplexityThreshold = 13,
+            FeaturePromotionSubstoryThreshold = 10
+        });
+        var task = new AgentTask { WorkItemId = 12345, AgentType = AgentType.Planning };
+
+        await service.ExecuteAsync(task);
+
+        Assert.Equal("AI Code", _capturedState.CurrentState);
+        _adoMock.Verify(a => a.AddWorkItemCommentAsync(12345,
+            It.Is<string>(c => c.Contains("Promote User Story to Feature")),
+            It.IsAny<CancellationToken>()), Times.Never);
+        _taskQueueMock.Verify(q => q.EnqueueAsync(
+            It.Is<AgentTask>(t => t.AgentType == AgentType.Coding),
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]

--- a/src/AIAgents.Functions.Tests/Helpers/MockAIResponses.cs
+++ b/src/AIAgents.Functions.Tests/Helpers/MockAIResponses.cs
@@ -193,6 +193,37 @@ public static class MockAIResponses
         testingStrategy = "Mock GitHub API responses, verify endpoint availability first"
     });
 
+
+    /// <summary>
+    /// Planning response that is ready but oversized and should trigger feature promotion recommendation.
+    /// </summary>
+    public static string OversizedPlanningResponse => JsonSerializer.Serialize(new
+    {
+        readiness = new
+        {
+            proceed = true,
+            readinessScore = 90,
+            blockers = Array.Empty<string>(),
+            questions = Array.Empty<string>(),
+            suggestedBreakdown = Array.Empty<string>(),
+            reason = "Story is implementable but too large for a single user story"
+        },
+        problemAnalysis = "Large cross-cutting effort spanning backend, frontend, and observability.",
+        technicalApproach = "Implement in decomposed vertical slices.",
+        affectedFiles = new[] { "src/A.cs", "src/B.cs" },
+        complexity = 13,
+        architecture = "Layered",
+        subTasks = new[]
+        {
+            "Define API contracts", "Implement service layer", "Add persistence", "Add migration",
+            "Create UI flow", "Add telemetry", "Add alerting", "Integration tests", "Docs update"
+        },
+        dependencies = Array.Empty<string>(),
+        risks = new[] { "Scope is too broad" },
+        assumptions = Array.Empty<string>(),
+        testingStrategy = "Unit and integration tests"
+    });
+
     public static string MalformedPlanningResponse => "This is not valid JSON at all - just plain text analysis";
 
     public static string PlanningResponseInCodeFences => $"```json\n{ValidPlanningResponse}\n```";

--- a/src/AIAgents.Functions/Agents/PlanningAgentService.cs
+++ b/src/AIAgents.Functions/Agents/PlanningAgentService.cs
@@ -35,6 +35,7 @@ public sealed class PlanningAgentService : IAgentService
     private readonly ILogger<PlanningAgentService> _logger;
     private readonly IAgentTaskQueue _taskQueue;
     private readonly GitHubOptions? _githubOptions;
+    private readonly PlanningOptions _planningOptions;
     private readonly HttpClient? _gitHubHttpClient;
 
     public PlanningAgentService(
@@ -46,6 +47,7 @@ public sealed class PlanningAgentService : IAgentService
         ICodebaseContextProvider codebaseContext,
         ILogger<PlanningAgentService> logger,
         IAgentTaskQueue taskQueue,
+        IOptions<PlanningOptions>? planningOptions = null,
         IOptions<GitHubOptions>? githubOptions = null,
         IHttpClientFactory? httpClientFactory = null)
     {
@@ -57,6 +59,7 @@ public sealed class PlanningAgentService : IAgentService
         _codebaseContext = codebaseContext;
         _logger = logger;
         _taskQueue = taskQueue;
+        _planningOptions = planningOptions?.Value ?? new PlanningOptions();
         _githubOptions = githubOptions?.Value;
         _gitHubHttpClient = httpClientFactory?.CreateClient("GitHub");
     }
@@ -330,6 +333,66 @@ Analyze this story and create a comprehensive implementation plan.";
             await _adoClient.UpdateWorkItemStateAsync(workItem.Id, "Needs Revision", cancellationToken);
 
             _logger.LogInformation("Planning agent rejected WI-{WorkItemId}, moved to Needs Revision", task.WorkItemId);
+            return AgentResult.Ok(aiResult.Usage?.TotalTokens ?? 0, aiResult.Usage?.EstimatedCost ?? 0m);
+        }
+
+        // 13. Promotion gate for oversized User Stories
+        var promotionReasons = GetFeaturePromotionReasons(planResult, _planningOptions);
+        if (promotionReasons.Count > 0)
+        {
+            var decompositionSummary = BuildSuggestedDecompositionSummary(planResult);
+            var reasonList = string.Join("<br/>", promotionReasons.Select(reason => $"- {WebUtility.HtmlEncode(reason)}"));
+
+            var promotionComment = "<b>📈 Planning Recommendation — Promote User Story to Feature</b><br/>" +
+                "This story appears oversized for a single User Story and should be promoted to a Feature before coding begins.<br/><br/>" +
+                $"<b>Reasons:</b><br/>{reasonList}<br/><br/>" +
+                $"<b>Suggested Decomposition:</b><br/>{WebUtility.HtmlEncode(decompositionSummary)}<br/><br/>" +
+                "<i>Move this item back to AI Agent after decomposition into smaller stories.</i>";
+
+            await _adoClient.AddWorkItemCommentAsync(workItem.Id, promotionComment, cancellationToken);
+            await _adoClient.AddWorkItemCommentAsync(
+                workItem.Id,
+                "Moved to Needs Revision. Reason: Planning thresholds indicate this story should be promoted to a Feature.",
+                cancellationToken);
+
+            state.Agents["Planning"] = AgentStatus.Completed();
+            state.Agents["Planning"].AdditionalData = new Dictionary<string, object>
+            {
+                ["triageResult"] = "feature_promotion_recommended",
+                ["complexity"] = planResult.Complexity,
+                ["subTaskCount"] = planResult.SubTasks.Count
+            };
+            state.CurrentState = "Needs Revision";
+            state.CurrentStage = "Planning";
+            state.LastActivityUtc = DateTime.UtcNow;
+            state.Blockers = promotionReasons
+                .Select(reason => $"Feature promotion recommended: {reason}")
+                .ToList();
+            state.HandoffRef = new StoryHandoffReference
+            {
+                Source = "PlanningAgentService",
+                Stage = "Needs Revision",
+                CorrelationId = task.CorrelationId,
+                Details = "Story exceeded planning thresholds and should be promoted to a Feature."
+            };
+            state.AcceptanceTrace = acceptanceTrace;
+            state.Decisions.Add(new Decision
+            {
+                Agent = "Planning",
+                DecisionText = "Recommended feature promotion for oversized story",
+                Rationale = string.Join("; ", promotionReasons)
+            });
+            await context.SaveStateAsync(state, cancellationToken);
+
+            try { await _adoClient.UpdateWorkItemFieldAsync(workItem.Id, CustomFieldNames.Paths.LastAgent, "Planning", cancellationToken); }
+            catch { }
+
+            try { await _adoClient.UpdateWorkItemFieldAsync(workItem.Id, CustomFieldNames.Paths.CurrentAIAgent, string.Empty, cancellationToken); }
+            catch { }
+
+            await _adoClient.UpdateWorkItemStateAsync(workItem.Id, "Needs Revision", cancellationToken);
+
+            _logger.LogInformation("Planning agent recommended feature promotion for WI-{WorkItemId}; moved to Needs Revision", task.WorkItemId);
             return AgentResult.Ok(aiResult.Usage?.TotalTokens ?? 0, aiResult.Usage?.EstimatedCost ?? 0m);
         }
 
@@ -611,6 +674,33 @@ Analyze this story and create a comprehensive implementation plan.";
         var start = Math.Max(0, index - radius);
         var end = Math.Min(text.Length, index + radius);
         return text[start..end].Trim();
+    }
+
+    internal static List<string> GetFeaturePromotionReasons(PlanningResult planResult, PlanningOptions options)
+    {
+        var reasons = new List<string>();
+
+        if (planResult.Complexity > options.FeaturePromotionComplexityThreshold)
+        {
+            reasons.Add($"Complexity {planResult.Complexity} exceeds threshold {options.FeaturePromotionComplexityThreshold}");
+        }
+
+        if (planResult.SubTasks.Count > options.FeaturePromotionSubstoryThreshold)
+        {
+            reasons.Add($"Sub-story count {planResult.SubTasks.Count} exceeds threshold {options.FeaturePromotionSubstoryThreshold}");
+        }
+
+        return reasons;
+    }
+
+    internal static string BuildSuggestedDecompositionSummary(PlanningResult planResult)
+    {
+        if (planResult.SubTasks.Count == 0)
+        {
+            return "Split the story into smaller, independently shippable vertical slices aligned to acceptance criteria.";
+        }
+
+        return string.Join("; ", planResult.SubTasks.Take(5));
     }
 
     private async Task<string> BuildTargetedFileContextAsync(

--- a/src/AIAgents.Functions/Program.cs
+++ b/src/AIAgents.Functions/Program.cs
@@ -27,6 +27,7 @@ var host = new HostBuilder()
         services.Configure<InputValidationOptions>(configuration.GetSection(InputValidationOptions.SectionName));
         services.Configure<CopilotOptions>(configuration.GetSection(CopilotOptions.SectionName));
         services.Configure<SaasOptions>(configuration.GetSection(SaasOptions.SectionName));
+        services.Configure<PlanningOptions>(configuration.GetSection(PlanningOptions.SectionName));
 
         // Application Insights — register BEFORE HTTP resilience handlers
         try


### PR DESCRIPTION
### Motivation
- Prevent oversized User Stories from being auto-processed into coding by having the Planning agent recommend promotion to a Feature when a story is too large. 
- Expose configurable thresholds so operators can tune when promotion recommendations are triggered.

### Description
- Add `PlanningOptions` bound to the `Planning` configuration section with `FeaturePromotionComplexityThreshold` and `FeaturePromotionSubstoryThreshold` in `src/AIAgents.Core/Configuration/PlanningOptions.cs`.
- Register `PlanningOptions` in DI in `src/AIAgents.Functions/Program.cs` so the planning agent can consume configuration via `IOptions<PlanningOptions>`.
- Update `PlanningAgentService` to accept `PlanningOptions`, evaluate `PlanningResult.Complexity` and `PlanningResult.SubTasks.Count` against thresholds, and if exceeded post a promotion recommendation comment, include encoded reasons and a suggested decomposition summary, set state to `Needs Revision`, add decision metadata, and return early without enqueueing the Coding agent (no auto-spawn of downstream work).
- Add helpers `GetFeaturePromotionReasons` and `BuildSuggestedDecompositionSummary` to centralize threshold logic and decomposition text, and add a deterministic `OversizedPlanningResponse` fixture for tests.
- Add unit tests covering the promotion and non-promotion paths in `src/AIAgents.Functions.Tests/Agents/PlanningAgentServiceTests.cs`.

### Testing
- Added unit tests: `ExecuteAsync_OversizedStory_PostsPromotionRecommendationAndMovesToNeedsRevision` and `ExecuteAsync_BelowPromotionThreshold_ProceedsToCoding` which assert comment posting, state change to `Needs Revision`, and that coding is not enqueued when thresholds are exceeded, and the inverse when below thresholds.
- Included `MockAIResponses.OversizedPlanningResponse` fixture to drive the oversized-path test.
- Attempted to run `dotnet test` for the Planning agent tests, but `dotnet` is not available in this execution environment so automated tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a2733ffc8321b1ce445a7d4c6717)