### PR TITLE
Add decomposition execution support for Planning completion

### DIFF
--- a/src/AIAgents.Core/Interfaces/IAzureDevOpsClient.cs
+++ b/src/AIAgents.Core/Interfaces/IAzureDevOpsClient.cs
@@ -52,6 +52,33 @@ public interface IAzureDevOpsClient
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Creates a child User Story with full planning payload and autonomy level.
+    /// </summary>
+    Task<int> CreateChildWorkItemAsync(
+        string title,
+        string description,
+        string acceptanceCriteria,
+        string state,
+        int autonomyLevel,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Links parent and child work items.
+    /// </summary>
+    Task AddParentChildLinkAsync(int parentWorkItemId, int childWorkItemId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Adds predecessor/successor dependency link between two stories.
+    /// predecessor -> successor.
+    /// </summary>
+    Task AddPredecessorSuccessorLinkAsync(int predecessorWorkItemId, int successorWorkItemId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns predecessor/successor related work item ids for the given work item.
+    /// </summary>
+    Task<IReadOnlyList<int>> GetDependencyLinkedWorkItemIdsAsync(int workItemId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Downloads supporting artifacts (images and documents) referenced by a work item into the local repository workspace.
     /// Files are materialized under the story folder so coding agents can inspect them directly.
     /// </summary>

--- a/src/AIAgents.Core/Models/PlanningResult.cs
+++ b/src/AIAgents.Core/Models/PlanningResult.cs
@@ -23,6 +23,20 @@ public sealed record PlanningResult
     /// When null, the story is assumed ready (backward compatibility).
     /// </summary>
     public PlanningReadiness? Readiness { get; init; }
+
+    /// <summary>
+    /// Optional child-story decomposition output from Planning.
+    /// When populated, decomposition spawning creates child stories and dependency links.
+    /// </summary>
+    public IReadOnlyList<FeatureDecompositionItem> FeatureDecomposition { get; init; } = [];
+}
+
+public sealed record FeatureDecompositionItem
+{
+    public required string Title { get; init; }
+    public string Description { get; init; } = string.Empty;
+    public string AcceptanceCriteria { get; init; } = string.Empty;
+    public IReadOnlyList<int> PredecessorIndexes { get; init; } = [];
 }
 
 /// <summary>

--- a/src/AIAgents.Core/Services/AzureDevOpsClient.cs
+++ b/src/AIAgents.Core/Services/AzureDevOpsClient.cs
@@ -244,7 +244,177 @@ public sealed class AzureDevOpsClient : IAzureDevOpsClient, IDisposable
         return workItemId;
     }
 
-    public async Task<WorkItemSupportingArtifacts> DownloadSupportingArtifactsAsync(
+    
+    public async Task<int> CreateChildWorkItemAsync(
+        string title,
+        string description,
+        string acceptanceCriteria,
+        string state,
+        int autonomyLevel,
+        CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Creating child work item: '{Title}' with state '{State}'", title, state);
+
+        var patchDocument = new JsonPatchDocument
+        {
+            new JsonPatchOperation
+            {
+                Operation = Operation.Add,
+                Path = "/fields/System.Title",
+                Value = title
+            },
+            new JsonPatchOperation
+            {
+                Operation = Operation.Add,
+                Path = "/fields/System.Description",
+                Value = description
+            },
+            new JsonPatchOperation
+            {
+                Operation = Operation.Add,
+                Path = "/fields/Microsoft.VSTS.Common.AcceptanceCriteria",
+                Value = acceptanceCriteria
+            },
+            new JsonPatchOperation
+            {
+                Operation = Operation.Add,
+                Path = "/fields/System.State",
+                Value = state
+            },
+            new JsonPatchOperation
+            {
+                Operation = Operation.Add,
+                Path = CustomFieldNames.Paths.AutonomyLevel,
+                Value = autonomyLevel.ToString()
+            },
+            new JsonPatchOperation
+            {
+                Operation = Operation.Add,
+                Path = CustomFieldNames.Paths.MinimumReviewScore,
+                Value = 85
+            }
+        };
+
+        var client = await _connection.Value.GetClientAsync<WorkItemTrackingHttpClient>(cancellationToken);
+        var workItem = await client.CreateWorkItemAsync(
+            patchDocument,
+            _options.Project,
+            "User Story",
+            cancellationToken: cancellationToken);
+
+        return workItem.Id ?? 0;
+    }
+
+    public async Task AddParentChildLinkAsync(int parentWorkItemId, int childWorkItemId, CancellationToken cancellationToken = default)
+    {
+        var client = await _connection.Value.GetClientAsync<WorkItemTrackingHttpClient>(cancellationToken);
+        var parentUrl = GetWorkItemApiUrl(parentWorkItemId);
+        var childUrl = GetWorkItemApiUrl(childWorkItemId);
+
+        await client.UpdateWorkItemAsync(
+            new JsonPatchDocument
+            {
+                new JsonPatchOperation
+                {
+                    Operation = Operation.Add,
+                    Path = "/relations/-",
+                    Value = new
+                    {
+                        rel = "System.LinkTypes.Hierarchy-Forward",
+                        url = childUrl,
+                        attributes = new { comment = "Added by decomposition" }
+                    }
+                }
+            },
+            parentWorkItemId,
+            cancellationToken: cancellationToken);
+
+        await client.UpdateWorkItemAsync(
+            new JsonPatchDocument
+            {
+                new JsonPatchOperation
+                {
+                    Operation = Operation.Add,
+                    Path = "/relations/-",
+                    Value = new
+                    {
+                        rel = "System.LinkTypes.Hierarchy-Reverse",
+                        url = parentUrl,
+                        attributes = new { comment = "Added by decomposition" }
+                    }
+                }
+            },
+            childWorkItemId,
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task AddPredecessorSuccessorLinkAsync(int predecessorWorkItemId, int successorWorkItemId, CancellationToken cancellationToken = default)
+    {
+        var client = await _connection.Value.GetClientAsync<WorkItemTrackingHttpClient>(cancellationToken);
+        var predecessorUrl = GetWorkItemApiUrl(predecessorWorkItemId);
+        var successorUrl = GetWorkItemApiUrl(successorWorkItemId);
+
+        await client.UpdateWorkItemAsync(
+            new JsonPatchDocument
+            {
+                new JsonPatchOperation
+                {
+                    Operation = Operation.Add,
+                    Path = "/relations/-",
+                    Value = new
+                    {
+                        rel = "System.LinkTypes.Dependency-Forward",
+                        url = successorUrl,
+                        attributes = new { comment = "Added by decomposition" }
+                    }
+                }
+            },
+            predecessorWorkItemId,
+            cancellationToken: cancellationToken);
+
+        await client.UpdateWorkItemAsync(
+            new JsonPatchDocument
+            {
+                new JsonPatchOperation
+                {
+                    Operation = Operation.Add,
+                    Path = "/relations/-",
+                    Value = new
+                    {
+                        rel = "System.LinkTypes.Dependency-Reverse",
+                        url = predecessorUrl,
+                        attributes = new { comment = "Added by decomposition" }
+                    }
+                }
+            },
+            successorWorkItemId,
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<int>> GetDependencyLinkedWorkItemIdsAsync(int workItemId, CancellationToken cancellationToken = default)
+    {
+        var client = await _connection.Value.GetClientAsync<WorkItemTrackingHttpClient>(cancellationToken);
+        var workItem = await client.GetWorkItemAsync(workItemId, expand: WorkItemExpand.Relations, cancellationToken: cancellationToken);
+        if (workItem.Relations is null)
+            return [];
+
+        var ids = new List<int>();
+        foreach (var relation in workItem.Relations)
+        {
+            if (!string.Equals(relation.Rel, "System.LinkTypes.Dependency-Forward", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(relation.Rel, "System.LinkTypes.Dependency-Reverse", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (TryParseWorkItemIdFromRelationUrl(relation.Url, out var relatedId))
+                ids.Add(relatedId);
+        }
+
+        return ids.Distinct().ToList();
+    }
+
+public async Task<WorkItemSupportingArtifacts> DownloadSupportingArtifactsAsync(
         int workItemId,
         string repositoryPath,
         CancellationToken cancellationToken = default)
@@ -342,6 +512,20 @@ public sealed class AzureDevOpsClient : IAzureDevOpsClient, IDisposable
         {
             _connection.Value.Dispose();
         }
+    }
+
+
+    private string GetWorkItemApiUrl(int workItemId)
+        => $"{_options.OrganizationUrl}/{_options.Project}/_apis/wit/workItems/{workItemId}";
+
+    private static bool TryParseWorkItemIdFromRelationUrl(string? relationUrl, out int workItemId)
+    {
+        workItemId = 0;
+        if (string.IsNullOrWhiteSpace(relationUrl))
+            return false;
+
+        var match = Regex.Match(relationUrl, @"/workItems/(?<id>\d+)", RegexOptions.IgnoreCase);
+        return match.Success && int.TryParse(match.Groups["id"].Value, out workItemId);
     }
 
     private static StoryWorkItem MapToStoryWorkItem(WorkItem workItem)

--- a/src/AIAgents.Functions.Tests/Agents/PlanningAgentServiceTests.cs
+++ b/src/AIAgents.Functions.Tests/Agents/PlanningAgentServiceTests.cs
@@ -26,6 +26,7 @@ public sealed class PlanningAgentServiceTests
     private readonly Mock<ITemplateEngine> _templateMock;
     private readonly Mock<ICodebaseContextProvider> _codebaseMock;
     private readonly Mock<IAgentTaskQueue> _taskQueueMock;
+    private readonly Mock<IWorkItemDecompositionService> _decompositionServiceMock;
 
     private StoryState _capturedState = null!;
 
@@ -40,6 +41,7 @@ public sealed class PlanningAgentServiceTests
         _templateMock = new Mock<ITemplateEngine>();
         _codebaseMock = new Mock<ICodebaseContextProvider>();
         _taskQueueMock = new Mock<IAgentTaskQueue>();
+        _decompositionServiceMock = new Mock<IWorkItemDecompositionService>();
 
         _aiFactoryMock.Setup(f => f.GetClientForAgent("Planning", It.IsAny<StoryModelOverrides?>())).Returns(_aiClientMock.Object);
         _contextFactoryMock.Setup(f => f.Create(It.IsAny<int>(), It.IsAny<string>())).Returns(_contextMock.Object);
@@ -55,7 +57,8 @@ public sealed class PlanningAgentServiceTests
             _templateMock.Object,
             _codebaseMock.Object,
             NullLogger<PlanningAgentService>.Instance,
-            _taskQueueMock.Object);
+            _taskQueueMock.Object,
+            _decompositionServiceMock.Object);
     }
 
     private void SetupHappyPath(StoryWorkItem? workItem = null, string? aiResponse = null)
@@ -567,5 +570,38 @@ public sealed class PlanningAgentServiceTests
         // Should find TBD in title, TODO and "need to decide" in description
         Assert.Contains("Title", result);
         Assert.Contains("Description", result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithFeatureDecomposition_InvokesSpawnService()
+    {
+        var aiResponse = """
+{
+  "readiness": { "proceed": true, "readinessScore": 90, "blockers": [], "questions": [], "researchNeeded": [], "suggestedBreakdown": [], "reason": "ready" },
+  "problemAnalysis": "ok",
+  "technicalApproach": "ok",
+  "affectedFiles": ["src/Program.cs"],
+  "complexity": 5,
+  "architecture": "arc",
+  "subTasks": ["one"],
+  "dependencies": [],
+  "risks": [],
+  "assumptions": [],
+  "testingStrategy": "unit",
+  "featureDecomposition": [
+    { "title": "Child 1", "description": "desc", "acceptanceCriteria": "ac", "predecessors": [] }
+  ]
+}
+""";
+        SetupHappyPath(aiResponse: aiResponse);
+        var service = CreateService();
+
+        await service.ExecuteAsync(new AgentTask { WorkItemId = 12345, AgentType = AgentType.Planning, CorrelationId = "corr-9" });
+
+        _decompositionServiceMock.Verify(x => x.SpawnDecompositionAsync(
+            It.Is<StoryWorkItem>(w => w.Id == 12345),
+            It.Is<PlanningResult>(r => r.FeatureDecomposition.Count == 1),
+            "corr-9",
+            It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/src/AIAgents.Functions.Tests/Services/WorkItemDecompositionServiceTests.cs
+++ b/src/AIAgents.Functions.Tests/Services/WorkItemDecompositionServiceTests.cs
@@ -1,0 +1,103 @@
+using AIAgents.Core.Constants;
+using AIAgents.Core.Interfaces;
+using AIAgents.Core.Models;
+using AIAgents.Functions.Models;
+using AIAgents.Functions.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace AIAgents.Functions.Tests.Services;
+
+public sealed class WorkItemDecompositionServiceTests
+{
+    [Fact]
+    public async Task SpawnDecompositionAsync_CreatesChildrenInPlanOrder_AndLinksDependencies()
+    {
+        var adoMock = new Mock<IAzureDevOpsClient>();
+        var queueMock = new Mock<IAgentTaskQueue>();
+        var created = new Queue<int>(new[] { 101, 102, 103 });
+
+        adoMock.Setup(x => x.CreateChildWorkItemAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), 3, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => created.Dequeue());
+
+        var service = new WorkItemDecompositionService(adoMock.Object, queueMock.Object, NullLogger<WorkItemDecompositionService>.Instance);
+
+        var plan = new PlanningResult
+        {
+            ProblemAnalysis = "p",
+            TechnicalApproach = "t",
+            AffectedFiles = [],
+            Complexity = 5,
+            Architecture = "a",
+            SubTasks = [],
+            Dependencies = [],
+            Risks = [],
+            Assumptions = [],
+            TestingStrategy = "tests",
+            FeatureDecomposition =
+            [
+                new FeatureDecompositionItem { Title = "A", Description = "d1", AcceptanceCriteria = "ac1", PredecessorIndexes = [] },
+                new FeatureDecompositionItem { Title = "B", Description = "d2", AcceptanceCriteria = "ac2", PredecessorIndexes = [0] },
+                new FeatureDecompositionItem { Title = "C", Description = "d3", AcceptanceCriteria = "ac3", PredecessorIndexes = [1] }
+            ]
+        };
+
+        await service.SpawnDecompositionAsync(new StoryWorkItem { Id = 77, Title = "Parent", State = "Story Planning", AutonomyLevel = 3 }, plan, "corr-1");
+
+        adoMock.Verify(x => x.CreateChildWorkItemAsync("A", "d1", "ac1", "AI Agent", 3, It.IsAny<CancellationToken>()), Times.Once);
+        adoMock.Verify(x => x.CreateChildWorkItemAsync("B", "d2", "ac2", "New", 3, It.IsAny<CancellationToken>()), Times.Once);
+        adoMock.Verify(x => x.CreateChildWorkItemAsync("C", "d3", "ac3", "New", 3, It.IsAny<CancellationToken>()), Times.Once);
+
+        adoMock.Verify(x => x.AddParentChildLinkAsync(77, 101, It.IsAny<CancellationToken>()), Times.Once);
+        adoMock.Verify(x => x.AddParentChildLinkAsync(77, 102, It.IsAny<CancellationToken>()), Times.Once);
+        adoMock.Verify(x => x.AddParentChildLinkAsync(77, 103, It.IsAny<CancellationToken>()), Times.Once);
+
+        adoMock.Verify(x => x.AddPredecessorSuccessorLinkAsync(101, 102, It.IsAny<CancellationToken>()), Times.Once);
+        adoMock.Verify(x => x.AddPredecessorSuccessorLinkAsync(102, 103, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SpawnDecompositionAsync_TriggersIndependentChildren_Only()
+    {
+        var adoMock = new Mock<IAzureDevOpsClient>();
+        var queueMock = new Mock<IAgentTaskQueue>();
+        var created = new Queue<int>(new[] { 201, 202 });
+
+        adoMock.Setup(x => x.CreateChildWorkItemAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), 4, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => created.Dequeue());
+
+        var service = new WorkItemDecompositionService(adoMock.Object, queueMock.Object, NullLogger<WorkItemDecompositionService>.Instance);
+
+        var plan = new PlanningResult
+        {
+            ProblemAnalysis = "p",
+            TechnicalApproach = "t",
+            AffectedFiles = [],
+            Complexity = 3,
+            Architecture = "a",
+            SubTasks = [],
+            Dependencies = [],
+            Risks = [],
+            Assumptions = [],
+            TestingStrategy = "tests",
+            FeatureDecomposition =
+            [
+                new FeatureDecompositionItem { Title = "Independent", Description = "d1", AcceptanceCriteria = "ac1", PredecessorIndexes = [] },
+                new FeatureDecompositionItem { Title = "Blocked", Description = "d2", AcceptanceCriteria = "ac2", PredecessorIndexes = [0] }
+            ]
+        };
+
+        await service.SpawnDecompositionAsync(new StoryWorkItem { Id = 88, Title = "Parent", State = "Story Planning", AutonomyLevel = 4 }, plan, "corr-2");
+
+        queueMock.Verify(x => x.EnqueueAsync(
+            It.Is<AgentTask>(t => t.WorkItemId == 201 && t.AgentType == AgentType.Planning && t.CorrelationId == "corr-2"),
+            It.IsAny<CancellationToken>()), Times.Once);
+
+        queueMock.Verify(x => x.EnqueueAsync(
+            It.Is<AgentTask>(t => t.WorkItemId == 202),
+            It.IsAny<CancellationToken>()), Times.Never);
+
+        adoMock.Verify(x => x.UpdateWorkItemFieldAsync(201, CustomFieldNames.Paths.CurrentAIAgent, AIPipelineNames.CurrentAgentValues.Planning, It.IsAny<CancellationToken>()), Times.Once);
+        adoMock.Verify(x => x.UpdateWorkItemFieldAsync(202, CustomFieldNames.Paths.CurrentAIAgent, AIPipelineNames.CurrentAgentValues.Planning, It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/src/AIAgents.Functions/Agents/PlanningAgentService.cs
+++ b/src/AIAgents.Functions/Agents/PlanningAgentService.cs
@@ -34,6 +34,7 @@ public sealed class PlanningAgentService : IAgentService
     private readonly ICodebaseContextProvider _codebaseContext;
     private readonly ILogger<PlanningAgentService> _logger;
     private readonly IAgentTaskQueue _taskQueue;
+    private readonly IWorkItemDecompositionService _decompositionService;
     private readonly GitHubOptions? _githubOptions;
     private readonly HttpClient? _gitHubHttpClient;
 
@@ -46,6 +47,7 @@ public sealed class PlanningAgentService : IAgentService
         ICodebaseContextProvider codebaseContext,
         ILogger<PlanningAgentService> logger,
         IAgentTaskQueue taskQueue,
+        IWorkItemDecompositionService decompositionService,
         IOptions<GitHubOptions>? githubOptions = null,
         IHttpClientFactory? httpClientFactory = null)
     {
@@ -57,6 +59,7 @@ public sealed class PlanningAgentService : IAgentService
         _codebaseContext = codebaseContext;
         _logger = logger;
         _taskQueue = taskQueue;
+        _decompositionService = decompositionService;
         _githubOptions = githubOptions?.Value;
         _gitHubHttpClient = httpClientFactory?.CreateClient("GitHub");
     }
@@ -157,9 +160,18 @@ Respond ONLY with valid JSON matching this structure:
   ""dependencies"": [""string""],
   ""risks"": [""string""],
   ""assumptions"": [""string""],
-  ""testingStrategy"": ""string""
+  ""testingStrategy"": ""string"",
+  ""featureDecomposition"": [
+    {
+      ""title"": ""string"",
+      ""description"": ""string"",
+      ""acceptanceCriteria"": ""string"",
+      ""predecessors"": [0]
+    }
+  ]
 }
 
+featureDecomposition is optional. Use it when the story should be split into executable child stories; predecessors contains zero-based indexes into the same array.
 ALWAYS include the full plan even when proceed=false — the analyst needs the analysis to fix the story.
 If unverified external dependencies are detected, add a warning note in the technicalApproach field.";
 
@@ -331,6 +343,11 @@ Analyze this story and create a comprehensive implementation plan.";
 
             _logger.LogInformation("Planning agent rejected WI-{WorkItemId}, moved to Needs Revision", task.WorkItemId);
             return AgentResult.Ok(aiResult.Usage?.TotalTokens ?? 0, aiResult.Usage?.EstimatedCost ?? 0m);
+        }
+
+        if (planResult.FeatureDecomposition.Count > 0)
+        {
+            await _decompositionService.SpawnDecompositionAsync(workItem, planResult, task.CorrelationId, cancellationToken);
         }
 
         // 13. Story IS ready — proceed to coding
@@ -532,7 +549,8 @@ Analyze this story and create a comprehensive implementation plan.";
                 Risks = GetStringArray(root, "risks"),
                 Assumptions = GetStringArray(root, "assumptions"),
                 TestingStrategy = root.GetProperty("testingStrategy").GetString() ?? "",
-                Readiness = readiness
+                Readiness = readiness,
+                FeatureDecomposition = ParseFeatureDecomposition(root)
             };
         }
         catch (JsonException)
@@ -549,9 +567,47 @@ Analyze this story and create a comprehensive implementation plan.";
                 Dependencies = [],
                 Risks = ["AI response could not be parsed as structured JSON"],
                 Assumptions = [],
-                TestingStrategy = "Unit and integration tests recommended"
+                TestingStrategy = "Unit and integration tests recommended",
+                FeatureDecomposition = []
             };
         }
+    }
+
+    private static IReadOnlyList<FeatureDecompositionItem> ParseFeatureDecomposition(JsonElement root)
+    {
+        if (!root.TryGetProperty("featureDecomposition", out var decompositionEl) || decompositionEl.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var items = new List<FeatureDecompositionItem>();
+        foreach (var childEl in decompositionEl.EnumerateArray())
+        {
+            if (childEl.ValueKind != JsonValueKind.Object)
+                continue;
+
+            var title = childEl.TryGetProperty("title", out var titleEl) ? titleEl.GetString() : null;
+            if (string.IsNullOrWhiteSpace(title))
+                continue;
+
+            var predecessors = new List<int>();
+            if (childEl.TryGetProperty("predecessors", out var predEl) && predEl.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var p in predEl.EnumerateArray())
+                {
+                    if (p.ValueKind == JsonValueKind.Number && p.TryGetInt32(out var idx))
+                        predecessors.Add(idx);
+                }
+            }
+
+            items.Add(new FeatureDecompositionItem
+            {
+                Title = title,
+                Description = childEl.TryGetProperty("description", out var descEl) ? descEl.GetString() ?? string.Empty : string.Empty,
+                AcceptanceCriteria = childEl.TryGetProperty("acceptanceCriteria", out var acEl) ? acEl.GetString() ?? string.Empty : string.Empty,
+                PredecessorIndexes = predecessors
+            });
+        }
+
+        return items;
     }
 
     private static List<string> GetStringArray(JsonElement root, string propertyName)

--- a/src/AIAgents.Functions/Program.cs
+++ b/src/AIAgents.Functions/Program.cs
@@ -113,6 +113,7 @@ var host = new HostBuilder()
 
         // Agent task queue — abstracts Azure Storage Queue for testability
         services.AddSingleton<IAgentTaskQueue, AgentTaskQueue>();
+        services.AddSingleton<IWorkItemDecompositionService, WorkItemDecompositionService>();
 
         // GitHub API context service — provides file tree, content, and write operations
         // without cloning the repository to local disk.

--- a/src/AIAgents.Functions/Services/IWorkItemDecompositionService.cs
+++ b/src/AIAgents.Functions/Services/IWorkItemDecompositionService.cs
@@ -1,0 +1,8 @@
+using AIAgents.Core.Models;
+
+namespace AIAgents.Functions.Services;
+
+public interface IWorkItemDecompositionService
+{
+    Task SpawnDecompositionAsync(StoryWorkItem parentWorkItem, PlanningResult planResult, string? correlationId, CancellationToken cancellationToken = default);
+}

--- a/src/AIAgents.Functions/Services/WorkItemDecompositionService.cs
+++ b/src/AIAgents.Functions/Services/WorkItemDecompositionService.cs
@@ -1,0 +1,93 @@
+using AIAgents.Core.Constants;
+using AIAgents.Core.Interfaces;
+using AIAgents.Core.Models;
+using AIAgents.Functions.Models;
+using Microsoft.Extensions.Logging;
+
+namespace AIAgents.Functions.Services;
+
+public sealed class WorkItemDecompositionService : IWorkItemDecompositionService
+{
+    private readonly IAzureDevOpsClient _adoClient;
+    private readonly IAgentTaskQueue _taskQueue;
+    private readonly ILogger<WorkItemDecompositionService> _logger;
+
+    public WorkItemDecompositionService(
+        IAzureDevOpsClient adoClient,
+        IAgentTaskQueue taskQueue,
+        ILogger<WorkItemDecompositionService> logger)
+    {
+        _adoClient = adoClient;
+        _taskQueue = taskQueue;
+        _logger = logger;
+    }
+
+    public async Task SpawnDecompositionAsync(StoryWorkItem parentWorkItem, PlanningResult planResult, string? correlationId, CancellationToken cancellationToken = default)
+    {
+        if (planResult.FeatureDecomposition.Count == 0)
+        {
+            return;
+        }
+
+        var createdChildIds = new List<int>(planResult.FeatureDecomposition.Count);
+
+        for (var index = 0; index < planResult.FeatureDecomposition.Count; index++)
+        {
+            var child = planResult.FeatureDecomposition[index];
+            var blocked = child.PredecessorIndexes.Count > 0;
+            var childState = blocked ? "New" : "AI Agent";
+
+            var childId = await _adoClient.CreateChildWorkItemAsync(
+                child.Title,
+                child.Description,
+                child.AcceptanceCriteria,
+                childState,
+                parentWorkItem.AutonomyLevel,
+                cancellationToken);
+
+            createdChildIds.Add(childId);
+            await _adoClient.AddParentChildLinkAsync(parentWorkItem.Id, childId, cancellationToken);
+
+            if (!blocked)
+            {
+                try
+                {
+                    await _adoClient.UpdateWorkItemFieldAsync(
+                        childId,
+                        CustomFieldNames.Paths.CurrentAIAgent,
+                        AIPipelineNames.CurrentAgentValues.Planning,
+                        cancellationToken);
+                }
+                catch
+                {
+                }
+
+                await _taskQueue.EnqueueAsync(new AgentTask
+                {
+                    WorkItemId = childId,
+                    AgentType = AgentType.Planning,
+                    CorrelationId = correlationId,
+                    TriggerSource = "FeatureDecomposition"
+                }, cancellationToken);
+            }
+        }
+
+        for (var index = 0; index < planResult.FeatureDecomposition.Count; index++)
+        {
+            var child = planResult.FeatureDecomposition[index];
+            var successorId = createdChildIds[index];
+            foreach (var predecessorIndex in child.PredecessorIndexes)
+            {
+                if (predecessorIndex < 0 || predecessorIndex >= createdChildIds.Count)
+                {
+                    continue;
+                }
+
+                var predecessorId = createdChildIds[predecessorIndex];
+                await _adoClient.AddPredecessorSuccessorLinkAsync(predecessorId, successorId, cancellationToken);
+            }
+        }
+
+        _logger.LogInformation("Spawned {Count} decomposition children for WI-{WorkItemId}", createdChildIds.Count, parentWorkItem.Id);
+    }
+}


### PR DESCRIPTION
### Motivation

- Allow the Planning agent to emit an explicit feature decomposition and have the system create executable child stories automatically. 
- Ensure child stories inherit parent autonomy and that independent children are triggered immediately while blocked children remain in `New` until dependencies resolve. 
- Provide traceability by creating parent-child and predecessor/successor links so downstream orchestration and reporting can rely on ADO relationships.

### Description

- Added `FeatureDecomposition` support to the planning model via `FeatureDecompositionItem` and extended `PlanningResult` to carry decomposition output, and added JSON parsing for `featureDecomposition` in `PlanningAgentService` (`ParseFeatureDecomposition`).
- Introduced `IWorkItemDecompositionService` and implemented `WorkItemDecompositionService` with `SpawnDecompositionAsync` that: creates children in plan order, sets child autonomy = parent autonomy, creates parent-child links, creates predecessor/successor links, enqueues independent children for `Planning` and leaves blocked children in `New`.
- Extended `IAzureDevOpsClient`/`AzureDevOpsClient` with `CreateChildWorkItemAsync`, `AddParentChildLinkAsync`, `AddPredecessorSuccessorLinkAsync`, and `GetDependencyLinkedWorkItemIdsAsync` to support full child payloads and linking operations.
- Wired decomposition execution into the Planning completion path by invoking `SpawnDecompositionAsync` before the parent handoff to Coding, and registered `IWorkItemDecompositionService` in DI (`Program.cs`).
- Added unit tests: `WorkItemDecompositionServiceTests` for child creation order, links, and trigger vs blocked behavior, and an added test in `PlanningAgentServiceTests` verifying decomposition invocation.

### Testing

- Added automated unit tests covering decomposition creation order, parent-child and predecessor/successor linking, and immediate-trigger vs blocked behavior (`src/AIAgents.Functions.Tests/Services/WorkItemDecompositionServiceTests.cs`) and Planning-path invocation (`PlanningAgentServiceTests`).
- Attempted to run the test suite with `dotnet test`, but the environment lacks the `dotnet` runtime so the run failed with `bash: command not found: dotnet`, therefore tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a292b5d48321b11d55661a396a65)