### PR TITLE
Implement merge-driven DAG progression for merged PR events

### DIFF
--- a/src/AIAgents.Core/Interfaces/IAzureDevOpsClient.cs
+++ b/src/AIAgents.Core/Interfaces/IAzureDevOpsClient.cs
@@ -59,4 +59,14 @@ public interface IAzureDevOpsClient
         int workItemId,
         string repositoryPath,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets successor work item IDs linked from this work item via ADO dependency links.
+    /// </summary>
+    Task<IReadOnlyList<int>> GetSuccessorIdsAsync(int workItemId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets predecessor work item IDs linked to this work item via ADO dependency links.
+    /// </summary>
+    Task<IReadOnlyList<int>> GetPredecessorIdsAsync(int workItemId, CancellationToken cancellationToken = default);
 }

--- a/src/AIAgents.Core/Services/AzureDevOpsClient.cs
+++ b/src/AIAgents.Core/Services/AzureDevOpsClient.cs
@@ -244,6 +244,20 @@ public sealed class AzureDevOpsClient : IAzureDevOpsClient, IDisposable
         return workItemId;
     }
 
+
+    public async Task<IReadOnlyList<int>> GetSuccessorIdsAsync(int workItemId, CancellationToken cancellationToken = default)
+    {
+        var client = await _connection.Value.GetClientAsync<WorkItemTrackingHttpClient>(cancellationToken);
+        var workItem = await client.GetWorkItemAsync(workItemId, expand: WorkItemExpand.Relations, cancellationToken: cancellationToken);
+        return ExtractRelatedIds(workItem, "System.LinkTypes.Dependency-Forward");
+    }
+
+    public async Task<IReadOnlyList<int>> GetPredecessorIdsAsync(int workItemId, CancellationToken cancellationToken = default)
+    {
+        var client = await _connection.Value.GetClientAsync<WorkItemTrackingHttpClient>(cancellationToken);
+        var workItem = await client.GetWorkItemAsync(workItemId, expand: WorkItemExpand.Relations, cancellationToken: cancellationToken);
+        return ExtractRelatedIds(workItem, "System.LinkTypes.Dependency-Reverse");
+    }
     public async Task<WorkItemSupportingArtifacts> DownloadSupportingArtifactsAsync(
         int workItemId,
         string repositoryPath,
@@ -406,6 +420,33 @@ public sealed class AzureDevOpsClient : IAzureDevOpsClient, IDisposable
                 ? (int)ci : null,
             AIDeploymentDecision = GetField<string>(fields, CustomFieldNames.DeploymentDecision)
         };
+    }
+
+
+    private static IReadOnlyList<int> ExtractRelatedIds(WorkItem workItem, string relationType)
+    {
+        if (workItem.Relations is null || workItem.Relations.Count == 0)
+        {
+            return [];
+        }
+
+        var ids = new List<int>();
+        foreach (var relation in workItem.Relations)
+        {
+            if (!string.Equals(relation.Rel, relationType, StringComparison.OrdinalIgnoreCase) || string.IsNullOrWhiteSpace(relation.Url))
+            {
+                continue;
+            }
+
+            var segments = relation.Url.Split('/', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var last = segments.Length > 0 ? segments[^1] : string.Empty;
+            if (int.TryParse(last, out var id))
+            {
+                ids.Add(id);
+            }
+        }
+
+        return ids;
     }
 
     private static T? GetField<T>(IDictionary<string, object> fields, string key)

--- a/src/AIAgents.Functions.Tests/Functions/CopilotBridgeWebhookTests.cs
+++ b/src/AIAgents.Functions.Tests/Functions/CopilotBridgeWebhookTests.cs
@@ -181,4 +181,13 @@ public sealed class CopilotBridgeWebhookTests
         Assert.Contains("CurrentAIAgent", missing);
         Assert.Contains("CompletionComment", missing);
     }
+
+
+    [Fact]
+    public void ExtractWorkItemIdFromBranch_FeatureBranch_ReturnsId()
+    {
+        var result = CopilotBridgeWebhook.ExtractWorkItemIdFromBranch("feature/US-31415");
+        Assert.Equal(31415, result);
+    }
+
 }

--- a/src/AIAgents.Functions.Tests/Functions/PRMergeOrchestrationFunctionTests.cs
+++ b/src/AIAgents.Functions.Tests/Functions/PRMergeOrchestrationFunctionTests.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using AIAgents.Core.Interfaces;
+using AIAgents.Core.Models;
+using AIAgents.Functions.Functions;
+using AIAgents.Functions.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace AIAgents.Functions.Tests.Functions;
+
+public sealed class PRMergeOrchestrationFunctionTests
+{
+    [Fact]
+    public async Task SingleMerge_UnlocksSingleSuccessor()
+    {
+        var ado = new Mock<IAzureDevOpsClient>();
+        var dedupe = new Mock<IMergeEventDeduplicationStore>();
+        dedupe.Setup(x => x.TryProcessAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        ado.Setup(x => x.GetSuccessorIdsAsync(123, It.IsAny<CancellationToken>())).ReturnsAsync([456]);
+        ado.Setup(x => x.GetPredecessorIdsAsync(456, It.IsAny<CancellationToken>())).ReturnsAsync([123]);
+        ado.Setup(x => x.GetWorkItemAsync(123, It.IsAny<CancellationToken>())).ReturnsAsync(new StoryWorkItem
+        {
+            Id = 123,
+            Title = "US-123",
+            State = "Done",
+            CreatedDate = DateTime.UtcNow,
+            ChangedDate = DateTime.UtcNow
+        });
+
+        var sut = new PRMergeOrchestrationFunction(ado.Object, dedupe.Object, Mock.Of<ILogger<PRMergeOrchestrationFunction>>());
+        var root = JsonDocument.Parse(MergedPayload(1, "feature/US-123", "abc")).RootElement;
+
+        var processed = await sut.ProcessMergedPullRequestAsync(root, CancellationToken.None);
+
+        Assert.True(processed);
+        ado.Verify(x => x.UpdateWorkItemStateAsync(456, "AI Agent", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task MultiPredecessor_UnlocksOnlyAfterFinalPredecessorDone()
+    {
+        var ado = new Mock<IAzureDevOpsClient>();
+        var dedupe = new Mock<IMergeEventDeduplicationStore>();
+        dedupe.Setup(x => x.TryProcessAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        ado.Setup(x => x.GetSuccessorIdsAsync(100, It.IsAny<CancellationToken>())).ReturnsAsync([200]);
+        ado.Setup(x => x.GetPredecessorIdsAsync(200, It.IsAny<CancellationToken>())).ReturnsAsync([100, 101]);
+        ado.Setup(x => x.GetWorkItemAsync(100, It.IsAny<CancellationToken>())).ReturnsAsync(BuildStory(100, "Done"));
+        ado.Setup(x => x.GetWorkItemAsync(101, It.IsAny<CancellationToken>())).ReturnsAsync(BuildStory(101, "Active"));
+
+        var sut = new PRMergeOrchestrationFunction(ado.Object, dedupe.Object, Mock.Of<ILogger<PRMergeOrchestrationFunction>>());
+        var root = JsonDocument.Parse(MergedPayload(9, "feature/US-100", "sha1")).RootElement;
+
+        await sut.ProcessMergedPullRequestAsync(root, CancellationToken.None);
+        ado.Verify(x => x.UpdateWorkItemStateAsync(200, "AI Agent", It.IsAny<CancellationToken>()), Times.Never);
+
+        ado.Setup(x => x.GetWorkItemAsync(101, It.IsAny<CancellationToken>())).ReturnsAsync(BuildStory(101, "Done"));
+        await sut.ProcessMergedPullRequestAsync(root, CancellationToken.None);
+        ado.Verify(x => x.UpdateWorkItemStateAsync(200, "AI Agent", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DuplicateMergeEvent_IsSuppressed()
+    {
+        var ado = new Mock<IAzureDevOpsClient>();
+        var dedupe = new Mock<IMergeEventDeduplicationStore>();
+        dedupe.SetupSequence(x => x.TryProcessAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true)
+            .ReturnsAsync(false);
+
+        ado.Setup(x => x.GetSuccessorIdsAsync(123, It.IsAny<CancellationToken>())).ReturnsAsync([456]);
+        ado.Setup(x => x.GetPredecessorIdsAsync(456, It.IsAny<CancellationToken>())).ReturnsAsync([123]);
+        ado.Setup(x => x.GetWorkItemAsync(123, It.IsAny<CancellationToken>())).ReturnsAsync(BuildStory(123, "Done"));
+
+        var sut = new PRMergeOrchestrationFunction(ado.Object, dedupe.Object, Mock.Of<ILogger<PRMergeOrchestrationFunction>>());
+        var root = JsonDocument.Parse(MergedPayload(77, "feature/US-123", "sha77")).RootElement;
+
+        await sut.ProcessMergedPullRequestAsync(root, CancellationToken.None);
+        await sut.ProcessMergedPullRequestAsync(root, CancellationToken.None);
+
+        ado.Verify(x => x.UpdateWorkItemStateAsync(456, "AI Agent", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static StoryWorkItem BuildStory(int id, string state) => new()
+    {
+        Id = id,
+        Title = $"US-{id}",
+        State = state,
+        CreatedDate = DateTime.UtcNow,
+        ChangedDate = DateTime.UtcNow
+    };
+
+    private static string MergedPayload(int prNumber, string headRef, string mergeSha) => $$"""
+{
+  "action": "closed",
+  "pull_request": {
+    "number": {{prNumber}},
+    "merged": true,
+    "merge_commit_sha": "{{mergeSha}}",
+    "head": { "ref": "{{headRef}}" }
+  }
+}
+""";
+}

--- a/src/AIAgents.Functions/Functions/CopilotBridgeWebhook.cs
+++ b/src/AIAgents.Functions/Functions/CopilotBridgeWebhook.cs
@@ -504,6 +504,18 @@ public sealed class CopilotBridgeWebhook
         return match.Success && int.TryParse(match.Groups[1].Value, out var id) ? id : null;
     }
 
+
+    internal static int? ExtractWorkItemIdFromBranch(string? branchName)
+    {
+        if (string.IsNullOrWhiteSpace(branchName))
+        {
+            return null;
+        }
+
+        var match = System.Text.RegularExpressions.Regex.Match(branchName, @"US-(\d+)", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        return match.Success && int.TryParse(match.Groups[1].Value, out var id) ? id : null;
+    }
+
     internal static bool IsReadyToReconcile(string action, string prTitle, bool isDraft)
     {
         if (string.IsNullOrWhiteSpace(action))

--- a/src/AIAgents.Functions/Functions/PRMergeOrchestrationFunction.cs
+++ b/src/AIAgents.Functions/Functions/PRMergeOrchestrationFunction.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using System.Text.Json;
+using AIAgents.Core.Interfaces;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using AIAgents.Functions.Services;
+
+namespace AIAgents.Functions.Functions;
+
+public sealed class PRMergeOrchestrationFunction
+{
+    private readonly IAzureDevOpsClient _adoClient;
+    private readonly IMergeEventDeduplicationStore _dedupeStore;
+    private readonly ILogger<PRMergeOrchestrationFunction> _logger;
+
+    public PRMergeOrchestrationFunction(
+        IAzureDevOpsClient adoClient,
+        IMergeEventDeduplicationStore dedupeStore,
+        ILogger<PRMergeOrchestrationFunction> logger)
+    {
+        _adoClient = adoClient;
+        _dedupeStore = dedupeStore;
+        _logger = logger;
+    }
+
+    [Function("PRMergeOrchestrationFunction")]
+    public async Task<HttpResponseData> RunAsync(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "pr-merge-webhook")] HttpRequestData req,
+        CancellationToken cancellationToken)
+    {
+        var body = await req.ReadAsStringAsync();
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return req.CreateResponse(HttpStatusCode.BadRequest);
+        }
+
+        using var doc = JsonDocument.Parse(body);
+        var processed = await ProcessMergedPullRequestAsync(doc.RootElement, cancellationToken);
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteStringAsync(processed ? "Processed" : "Ignored", cancellationToken);
+        return response;
+    }
+
+    internal async Task<bool> ProcessMergedPullRequestAsync(JsonElement root, CancellationToken cancellationToken)
+    {
+        var action = root.TryGetProperty("action", out var actionProp) ? actionProp.GetString() : null;
+        if (!string.Equals(action, "closed", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (!root.TryGetProperty("pull_request", out var prNode) ||
+            !prNode.TryGetProperty("merged", out var mergedProp) ||
+            mergedProp.ValueKind != JsonValueKind.True)
+        {
+            return false;
+        }
+
+        var prNumber = prNode.GetProperty("number").GetInt32();
+        var mergeSha = prNode.TryGetProperty("merge_commit_sha", out var shaProp) ? shaProp.GetString() ?? string.Empty : string.Empty;
+        var headBranch = prNode.GetProperty("head").GetProperty("ref").GetString();
+
+        var storyId = CopilotBridgeWebhook.ExtractWorkItemIdFromBranch(headBranch);
+        if (storyId is null)
+        {
+            _logger.LogInformation("Merged PR #{PrNumber} branch {Branch} did not map to a story", prNumber, headBranch);
+            return false;
+        }
+
+        var dedupeKey = $"pr:{prNumber}:story:{storyId}:sha:{mergeSha}";
+        if (!await _dedupeStore.TryProcessAsync(dedupeKey, cancellationToken))
+        {
+            return false;
+        }
+
+        var successors = await _adoClient.GetSuccessorIdsAsync(storyId.Value, cancellationToken);
+        foreach (var successorId in successors)
+        {
+            var predecessors = await _adoClient.GetPredecessorIdsAsync(successorId, cancellationToken);
+            var allDone = true;
+
+            foreach (var predecessorId in predecessors)
+            {
+                var predecessor = await _adoClient.GetWorkItemAsync(predecessorId, cancellationToken);
+                if (!string.Equals(predecessor.State, "Done", StringComparison.OrdinalIgnoreCase))
+                {
+                    allDone = false;
+                    break;
+                }
+            }
+
+            if (allDone)
+            {
+                await _adoClient.UpdateWorkItemStateAsync(successorId, "AI Agent", cancellationToken);
+                _logger.LogInformation("Unlocked successor US-{SuccessorId} after merge for US-{StoryId}", successorId, storyId.Value);
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/AIAgents.Functions/Program.cs
+++ b/src/AIAgents.Functions/Program.cs
@@ -130,6 +130,7 @@ var host = new HostBuilder()
 
         // Copilot delegation tracking (Azure Table Storage)
         services.AddSingleton<ICopilotDelegationService, TableStorageCopilotDelegationService>();
+        services.AddSingleton<IMergeEventDeduplicationStore, TableMergeEventDeduplicationStore>();
         services.AddSingleton<IGitHubOrchestrationLauncherService>(sp =>
             new GitHubOrchestrationLauncherService(
                 sp.GetRequiredService<IOptions<GitHubOptions>>(),

--- a/src/AIAgents.Functions/Services/IMergeEventDeduplicationStore.cs
+++ b/src/AIAgents.Functions/Services/IMergeEventDeduplicationStore.cs
@@ -1,0 +1,6 @@
+namespace AIAgents.Functions.Services;
+
+public interface IMergeEventDeduplicationStore
+{
+    Task<bool> TryProcessAsync(string dedupeKey, CancellationToken cancellationToken = default);
+}

--- a/src/AIAgents.Functions/Services/TableMergeEventDeduplicationStore.cs
+++ b/src/AIAgents.Functions/Services/TableMergeEventDeduplicationStore.cs
@@ -1,0 +1,62 @@
+using Azure;
+using Azure.Data.Tables;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace AIAgents.Functions.Services;
+
+public sealed class TableMergeEventDeduplicationStore : IMergeEventDeduplicationStore
+{
+    private const string TableName = "MergeEventDedup";
+    private const string PartitionKey = "pr-merge";
+
+    private readonly TableClient _tableClient;
+    private readonly ILogger<TableMergeEventDeduplicationStore> _logger;
+
+    public TableMergeEventDeduplicationStore(IConfiguration configuration, ILogger<TableMergeEventDeduplicationStore> logger)
+    {
+        _logger = logger;
+        var connectionString = configuration["AzureWebJobsStorage"]
+            ?? throw new InvalidOperationException("AzureWebJobsStorage connection string is required.");
+
+        _tableClient = new TableClient(connectionString, TableName);
+        _tableClient.CreateIfNotExists();
+    }
+
+    public async Task<bool> TryProcessAsync(string dedupeKey, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _tableClient.AddEntityAsync(new TableEntity(PartitionKey, dedupeKey)
+            {
+                ["Processed"] = false,
+                ["UpdatedAt"] = DateTimeOffset.UtcNow
+            }, cancellationToken);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 409)
+        {
+            // Entity already exists; proceed to CAS claim attempt below.
+        }
+
+        var current = await _tableClient.GetEntityAsync<TableEntity>(PartitionKey, dedupeKey, cancellationToken: cancellationToken);
+        var entity = current.Value;
+        if (entity.GetBoolean("Processed") == true)
+        {
+            return false;
+        }
+
+        entity["Processed"] = true;
+        entity["UpdatedAt"] = DateTimeOffset.UtcNow;
+
+        try
+        {
+            await _tableClient.UpdateEntityAsync(entity, entity.ETag, TableUpdateMode.Replace, cancellationToken);
+            return true;
+        }
+        catch (RequestFailedException ex) when (ex.Status == 412)
+        {
+            _logger.LogInformation("Suppressed duplicate merge event (ETag CAS conflict) for {DedupeKey}", dedupeKey);
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Automatically advance downstream stories in the AI-agent DAG when a feature PR is merged so the pipeline can continue without manual intervention.
- Resolve story IDs from branch naming (e.g., `feature/US-123`) and only transition successors when all dependency predecessors are completed.
- Avoid duplicate/near-simultaneous processing of merge webhooks by using an optimistic concurrency deduplication store.

### Description
- Added a new HTTP function `PRMergeOrchestrationFunction` that handles `pull_request.closed` events with `merged=true`, extracts the story ID from the PR head branch, queries successors, checks predecessor completion, and transitions eligible successors to the `AI Agent` state (`src/AIAgents.Functions/Functions/PRMergeOrchestrationFunction.cs`).
- Added branch parsing helper `ExtractWorkItemIdFromBranch` to `CopilotBridgeWebhook` for `US-{id}` extraction from branch names (`src/AIAgents.Functions/Functions/CopilotBridgeWebhook.cs`).
- Extended `IAzureDevOpsClient` and `AzureDevOpsClient` with `GetSuccessorIdsAsync` and `GetPredecessorIdsAsync` and a helper to parse ADO relation URLs to extract linked work item IDs (`src/AIAgents.Core/Interfaces/IAzureDevOpsClient.cs`, `src/AIAgents.Core/Services/AzureDevOpsClient.cs`).
- Implemented an Azure Table-backed deduplication store `IMergeEventDeduplicationStore` + `TableMergeEventDeduplicationStore` that uses insert + ETag compare-and-swap semantics to suppress duplicate merge handling, and registered it in DI (`src/AIAgents.Functions/Services/*`, `src/AIAgents.Functions/Program.cs`).
- Added unit tests covering single-merge unlocking, multi-predecessor unlocking only after the final predecessor completes, and duplicate-merge suppression, and extended webhook tests with a branch-parsing case (`src/AIAgents.Functions.Tests/Functions/PRMergeOrchestrationFunctionTests.cs`, updated `CopilotBridgeWebhookTests.cs`).

### Testing
- Added unit tests: `PRMergeOrchestrationFunctionTests` (single merge, multi-predecessor, duplicate merge suppression) and an extra `CopilotBridgeWebhook` branch parsing test, but these are new files only (automated tests present in `src/AIAgents.Functions.Tests`).
- Attempted to execute the test suite with `dotnet test`, but the test runner was not available in this environment (`dotnet` command not found), so automated tests were not run here.
- Performed local repository checks to validate the workspace and DI registration; no automated test failures were produced in-repo because tests were not executed in this container.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a294dc548321875de4c79df73d55)