### PR TITLE
Add per-task dependency metadata to planning output and TASKS template

### DIFF
--- a/src/AIAgents.Core.Tests/Models/ModelSerializationTests.cs
+++ b/src/AIAgents.Core.Tests/Models/ModelSerializationTests.cs
@@ -225,6 +225,7 @@ public sealed class ModelSerializationTests
             Complexity = 8,
             Architecture = "Clean",
             SubTasks = ["Task 1"],
+            TaskDetails = [new PlanningTask { Title = "Task 1" }],
             Dependencies = ["Dep 1"],
             Risks = ["Risk 1"],
             Assumptions = ["Assume 1"],

--- a/src/AIAgents.Core.Tests/Services/ScribanTemplateEngineTests.cs
+++ b/src/AIAgents.Core.Tests/Services/ScribanTemplateEngineTests.cs
@@ -62,6 +62,15 @@ public sealed class ScribanTemplateEngineTests
             ["WORK_ITEM_ID"] = "US-100",
             ["TITLE"] = "Test Tasks",
             ["SUBTASKS"] = new List<string> { "Create model", "Implement service", "Write tests" },
+            ["TASK_DETAILS"] = new List<Dictionary<string, object?>>
+            {
+                new()
+                {
+                    ["Title"] = "Implement service",
+                    ["DependsOnTaskIndexes"] = new List<int> { 1 },
+                    ["DependsOnStoryIds"] = new List<string> { "US-88" }
+                }
+            },
             ["TIMESTAMP"] = "2026-01-01T00:00:00Z"
         };
 
@@ -71,6 +80,7 @@ public sealed class ScribanTemplateEngineTests
         Assert.Contains("Create model", result);
         Assert.Contains("Implement service", result);
         Assert.Contains("Write tests", result);
+        Assert.Contains("**DependsOn:** Task 1, US-88", result);
     }
 
     [Fact]
@@ -206,4 +216,29 @@ public sealed class ScribanTemplateEngineTests
         var result = await _engine.RenderAsync("PLAN.template.md", model);
         Assert.NotNull(result);
     }
+    [Fact]
+    public async Task RenderAsync_TasksTemplate_WithoutDependencies_DoesNotRenderDependsOn()
+    {
+        var model = new Dictionary<string, object?>
+        {
+            ["WORK_ITEM_ID"] = "US-101",
+            ["TITLE"] = "Test Tasks No Dependencies",
+            ["SUBTASKS"] = new List<string> { "Create model", "Implement service" },
+            ["TASK_DETAILS"] = new List<Dictionary<string, object?>>
+            {
+                new()
+                {
+                    ["Title"] = "Implement service",
+                    ["DependsOnTaskIndexes"] = new List<int>(),
+                    ["DependsOnStoryIds"] = new List<string>()
+                }
+            },
+            ["TIMESTAMP"] = "2026-01-01T00:00:00Z"
+        };
+
+        var result = await _engine.RenderAsync("TASKS.template.md", model);
+
+        Assert.DoesNotContain("**DependsOn:**", result);
+    }
+
 }

--- a/src/AIAgents.Core/Models/PlanningResult.cs
+++ b/src/AIAgents.Core/Models/PlanningResult.cs
@@ -13,6 +13,7 @@ public sealed record PlanningResult
     public required int Complexity { get; init; }
     public required string Architecture { get; init; }
     public required IReadOnlyList<string> SubTasks { get; init; }
+    public required IReadOnlyList<PlanningTask> TaskDetails { get; init; }
     public required IReadOnlyList<string> Dependencies { get; init; }
     public required IReadOnlyList<string> Risks { get; init; }
     public required IReadOnlyList<string> Assumptions { get; init; }
@@ -23,6 +24,16 @@ public sealed record PlanningResult
     /// When null, the story is assumed ready (backward compatibility).
     /// </summary>
     public PlanningReadiness? Readiness { get; init; }
+}
+
+/// <summary>
+/// Detailed planning task structure with optional dependency metadata.
+/// </summary>
+public sealed record PlanningTask
+{
+    public required string Title { get; init; }
+    public IReadOnlyList<int> DependsOnTaskIndexes { get; init; } = [];
+    public IReadOnlyList<string> DependsOnStoryIds { get; init; } = [];
 }
 
 /// <summary>

--- a/src/AIAgents.Core/Templates/TASKS.template.md
+++ b/src/AIAgents.Core/Templates/TASKS.template.md
@@ -8,6 +8,17 @@
 
 {{ for task in SUBTASKS }}
 ### {{ for.index + 1 }}. {{ task }}
+{{ task_detail = null }}
+{{ if TASK_DETAILS }}
+{{ for detail in TASK_DETAILS }}
+{{ if detail.Title == task }}
+{{ task_detail = detail }}
+{{ end }}
+{{ end }}
+{{ end }}
+{{ if task_detail && (task_detail.DependsOnTaskIndexes.size > 0 || task_detail.DependsOnStoryIds.size > 0) }}
+**DependsOn:** {{ first = true }}{{ for idx in task_detail.DependsOnTaskIndexes }}{{ if !first }}, {{ end }}Task {{ idx }}{{ first = false }}{{ end }}{{ for story_id in task_detail.DependsOnStoryIds }}{{ if !first }}, {{ end }}{{ story_id }}{{ first = false }}{{ end }}
+{{ end }}
 
 **Status:** To Do
 

--- a/src/AIAgents.Functions.Tests/Agents/PlanningAgentServiceTests.cs
+++ b/src/AIAgents.Functions.Tests/Agents/PlanningAgentServiceTests.cs
@@ -429,6 +429,10 @@ public sealed class PlanningAgentServiceTests
         Assert.NotNull(result.Readiness);
         Assert.True(result.Readiness.Proceed);
         Assert.Equal(92, result.Readiness.ReadinessScore);
+        Assert.Equal(4, result.TaskDetails.Count);
+        Assert.Equal("Implement RegistrationService", result.TaskDetails[1].Title);
+        Assert.Equal(new[] { 1 }, result.TaskDetails[1].DependsOnTaskIndexes);
+        Assert.Equal(new[] { "US-777" }, result.TaskDetails[2].DependsOnStoryIds);
     }
 
     [Fact]
@@ -450,6 +454,7 @@ public sealed class PlanningAgentServiceTests
         var result = PlanningAgentService.ParsePlanningResult(MockAIResponses.PlanningResponseNoReadiness);
 
         Assert.Null(result.Readiness);
+        Assert.Empty(result.TaskDetails);
     }
 
     [Fact]

--- a/src/AIAgents.Functions.Tests/Helpers/MockAIResponses.cs
+++ b/src/AIAgents.Functions.Tests/Helpers/MockAIResponses.cs
@@ -114,6 +114,13 @@ public static class MockAIResponses
         complexity = 8,
         architecture = "Clean architecture with service layer pattern",
         subTasks = new[] { "Create User model", "Implement RegistrationService", "Add AuthController endpoint", "Create email verification flow" },
+        taskDetails = new object[]
+        {
+            new { title = "Create User model", dependsOnTaskIndexes = Array.Empty<int>(), dependsOnStoryIds = Array.Empty<string>() },
+            new { title = "Implement RegistrationService", dependsOnTaskIndexes = new[] { 1 }, dependsOnStoryIds = Array.Empty<string>() },
+            new { title = "Add AuthController endpoint", dependsOnTaskIndexes = new[] { 2 }, dependsOnStoryIds = new[] { "US-777" } },
+            new { title = "Create email verification flow", dependsOnTaskIndexes = new[] { 2, 3 }, dependsOnStoryIds = Array.Empty<string>() }
+        },
         dependencies = new[] { "SMTP service", "Database migrations" },
         risks = new[] { "Email delivery reliability", "Token expiration handling" },
         assumptions = new[] { "SMTP server is available", "Database supports the schema" },

--- a/src/AIAgents.Functions/Agents/PlanningAgentService.cs
+++ b/src/AIAgents.Functions/Agents/PlanningAgentService.cs
@@ -154,6 +154,13 @@ Respond ONLY with valid JSON matching this structure:
   ""complexity"": number (1-13 fibonacci scale),
   ""architecture"": ""string"",
   ""subTasks"": [""string""],
+  ""taskDetails"": [
+    {
+      ""title"": ""string"",
+      ""dependsOnTaskIndexes"": [1],
+      ""dependsOnStoryIds"": [""US-123""]
+    }
+  ],
   ""dependencies"": [""string""],
   ""risks"": [""string""],
   ""assumptions"": [""string""],
@@ -161,7 +168,14 @@ Respond ONLY with valid JSON matching this structure:
 }
 
 ALWAYS include the full plan even when proceed=false — the analyst needs the analysis to fix the story.
-If unverified external dependencies are detected, add a warning note in the technicalApproach field.";
+If unverified external dependencies are detected, add a warning note in the technicalApproach field.
+
+TASK DEPENDENCY REQUIREMENTS:
+- In decomposition mode and story mode, emit dependency-bearing task structures via taskDetails whenever dependencies exist.
+- taskDetails must align 1:1 with subTasks by title/order when possible.
+- Use dependsOnTaskIndexes for dependencies on other tasks in this same plan (1-based indexes).
+- Use dependsOnStoryIds for sibling story dependencies (e.g., US-123, US-456) when cross-story dependencies are known.
+- If no dependencies exist for a task, emit empty arrays for that task's dependency fields.";
 
         var userPrompt = $@"## Story Details
 **ID:** {workItem.Id}
@@ -224,6 +238,7 @@ Analyze this story and create a comprehensive implementation plan.";
             ["WORK_ITEM_ID"] = $"US-{workItem.Id}",
             ["TITLE"] = workItem.Title,
             ["SUBTASKS"] = planResult.SubTasks,
+            ["TASK_DETAILS"] = planResult.TaskDetails,
             ["TIMESTAMP"] = DateTime.UtcNow.ToString("O")
         };
         var renderedTasks = await _templateEngine.RenderAsync("TASKS.template.md", tasksModel, cancellationToken);
@@ -528,6 +543,7 @@ Analyze this story and create a comprehensive implementation plan.";
                 Complexity = root.TryGetProperty("complexity", out var c) ? c.GetInt32() : 5,
                 Architecture = root.GetProperty("architecture").GetString() ?? "",
                 SubTasks = GetStringArray(root, "subTasks"),
+                TaskDetails = GetTaskDetails(root),
                 Dependencies = GetStringArray(root, "dependencies"),
                 Risks = GetStringArray(root, "risks"),
                 Assumptions = GetStringArray(root, "assumptions"),
@@ -546,12 +562,51 @@ Analyze this story and create a comprehensive implementation plan.";
                 Complexity = 5,
                 Architecture = "To be determined",
                 SubTasks = ["Review AI analysis", "Implement changes", "Write tests"],
+                TaskDetails = [],
                 Dependencies = [],
                 Risks = ["AI response could not be parsed as structured JSON"],
                 Assumptions = [],
                 TestingStrategy = "Unit and integration tests recommended"
             };
         }
+    }
+
+
+    private static List<PlanningTask> GetTaskDetails(JsonElement root)
+    {
+        if (!root.TryGetProperty("taskDetails", out var prop) || prop.ValueKind != JsonValueKind.Array)
+            return [];
+
+        var tasks = new List<PlanningTask>();
+        foreach (var item in prop.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object)
+                continue;
+
+            var title = item.TryGetProperty("title", out var titleEl) ? titleEl.GetString() : null;
+            if (string.IsNullOrWhiteSpace(title))
+                continue;
+
+            tasks.Add(new PlanningTask
+            {
+                Title = title!,
+                DependsOnTaskIndexes = GetIntArray(item, "dependsOnTaskIndexes"),
+                DependsOnStoryIds = GetStringArray(item, "dependsOnStoryIds")
+            });
+        }
+
+        return tasks;
+    }
+
+    private static List<int> GetIntArray(JsonElement root, string propertyName)
+    {
+        if (!root.TryGetProperty(propertyName, out var prop) || prop.ValueKind != JsonValueKind.Array)
+            return [];
+
+        return prop.EnumerateArray()
+            .Where(e => e.ValueKind == JsonValueKind.Number && e.TryGetInt32(out _))
+            .Select(e => e.GetInt32())
+            .ToList();
     }
 
     private static List<string> GetStringArray(JsonElement root, string propertyName)


### PR DESCRIPTION
### Motivation

- Enable the Planning agent to convey structured dependency metadata per subtask so downstream agents and human reviewers can see intra-plan and cross-story dependencies. 
- Make the task template show explicit `DependsOn:` lines when a subtask declares dependencies to improve handoffs in decomposition and story modes. 
- Add tests to validate template rendering and planning result parsing with and without dependency annotations.

### Description

- Introduced `PlanningTask` and a required `TaskDetails` property on `PlanningResult` to carry `Title`, `DependsOnTaskIndexes`, and `DependsOnStoryIds` metadata. 
- Extended the Planning agent prompt contract to request `taskDetails`, implemented `GetTaskDetails`/`GetIntArray` parsing helpers in `PlanningAgentService`, and pass `TASK_DETAILS` into the task rendering model. 
- Updated `TASKS.template.md` to look up task detail entries by title/order and print a `DependsOn:` line containing `Task N` references and sibling story IDs when present. 
- Added and updated unit tests and canned AI responses to cover parsing `taskDetails` and template rendering behavior (`ScribanTemplateEngineTests`, `PlanningAgentServiceTests`, `MockAIResponses`, and `ModelSerializationTests`).

### Testing

- Updated/added automated tests: `RenderAsync_TasksTemplate_RendersSubTasks`, `RenderAsync_TasksTemplate_WithoutDependencies_DoesNotRenderDependsOn`, `ParsePlanningResult_ParsesReadiness`, `ParsePlanningResult_NoReadinessField_ReturnsNull`, and `PlanningResult_AllProperties_Required` to validate parsing and template output. 
- Attempted to run `dotnet test src/AIAgents.Core.Tests/AIAgents.Core.Tests.csproj`, but test execution failed in this environment because `dotnet` is not installed (`bash: command not found: dotnet`).
- All tests were added/updated in source control and are expected to pass in a standard .NET build environment when executed there.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a29845448321aaaed5759fff454f)