### PR TITLE
Add managed onboarding control-plane scaffold (adom8-onboarding)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ terraform.rc
 
 # Node
 node_modules/
+.next/
+out/
 npm-debug.log*
 
 # IDE

--- a/adom8-onboarding/.ado/pipelines/deploy-shared.yml
+++ b/adom8-onboarding/.ado/pipelines/deploy-shared.yml
@@ -1,0 +1,44 @@
+trigger:
+  branches:
+    include:
+      - main
+
+stages:
+  - stage: DeployShared
+    jobs:
+      - job: Bicep
+        steps:
+          - task: AzureCLI@2
+            displayName: Deploy shared infrastructure
+            inputs:
+              azureSubscription: adom8-shared-connection
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                az deployment sub create \
+                  --location westus2 \
+                  --template-file infra/shared.bicep \
+                  --parameters resourceGroupName=rg-adom8-shared
+
+      - job: DeployRegistrationApi
+        dependsOn: Bicep
+        steps:
+          - task: DotNetCoreCLI@2
+            displayName: Build Registration API
+            inputs:
+              command: publish
+              projects: src/Functions/*.csproj
+
+          - task: AzureFunctionApp@2
+            displayName: Deploy Registration API
+            inputs:
+              azureSubscription: adom8-shared-connection
+              appName: fa-adom8-registration
+
+      - job: DeployOnboardingUI
+        dependsOn: Bicep
+        steps:
+          - task: AzureStaticWebApp@0
+            inputs:
+              app_location: src/web
+              output_location: out

--- a/adom8-onboarding/.ado/pipelines/deploy-shared.yml
+++ b/adom8-onboarding/.ado/pipelines/deploy-shared.yml
@@ -3,6 +3,13 @@ trigger:
     include:
       - main
 
+variables:
+  azureServiceConnection: adom8-shared-connection
+  location: westus2
+  sharedResourceGroupName: rg-adom8-shared
+  onboardingFunctionAppName: fa-adom8-registration
+  onboardingStaticWebAppName: stapp-adom8-onboarding
+
 stages:
   - stage: DeployShared
     jobs:
@@ -11,14 +18,18 @@ stages:
           - task: AzureCLI@2
             displayName: Deploy shared infrastructure
             inputs:
-              azureSubscription: adom8-shared-connection
+              azureSubscription: $(azureServiceConnection)
               scriptType: bash
               scriptLocation: inlineScript
               inlineScript: |
                 az deployment sub create \
-                  --location westus2 \
-                  --template-file infra/shared.bicep \
-                  --parameters resourceGroupName=rg-adom8-shared
+                  --location $(location) \
+                  --template-file adom8-onboarding/infra/shared.bicep \
+                  --parameters \
+                    resourceGroupName=$(sharedResourceGroupName) \
+                    location=$(location) \
+                    onboardingFunctionAppName=$(onboardingFunctionAppName) \
+                    onboardingStaticWebAppName=$(onboardingStaticWebAppName)
 
       - job: DeployRegistrationApi
         dependsOn: Bicep
@@ -27,18 +38,81 @@ stages:
             displayName: Build Registration API
             inputs:
               command: publish
-              projects: src/Functions/*.csproj
+              publishWebProjects: false
+              projects: adom8-onboarding/src/Functions/adom8-onboarding.csproj
+              arguments: --configuration Release --output $(Build.ArtifactStagingDirectory)/onboarding-functions
+              zipAfterPublish: true
 
           - task: AzureFunctionApp@2
             displayName: Deploy Registration API
             inputs:
-              azureSubscription: adom8-shared-connection
-              appName: fa-adom8-registration
+              azureSubscription: $(azureServiceConnection)
+              appType: functionApp
+              appName: $(onboardingFunctionAppName)
+              package: $(Build.ArtifactStagingDirectory)/onboarding-functions/**/*.zip
 
       - job: DeployOnboardingUI
-        dependsOn: Bicep
+        dependsOn:
+          - Bicep
+          - DeployRegistrationApi
         steps:
+          - task: NodeTool@0
+            inputs:
+              versionSpec: 20.x
+            displayName: Install Node.js 20
+
+          - script: npm ci
+            workingDirectory: adom8-onboarding/src/web
+            displayName: Install onboarding UI dependencies
+
+          - task: AzureCLI@2
+            displayName: Fetch onboarding API settings
+            inputs:
+              azureSubscription: $(azureServiceConnection)
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                subscriptionId=$(az account show --query id -o tsv)
+                functionKey=$(az rest --method post \
+                  --uri "https://management.azure.com/subscriptions/${subscriptionId}/resourceGroups/$(sharedResourceGroupName)/providers/Microsoft.Web/sites/$(onboardingFunctionAppName)/host/default/listKeys?api-version=2022-03-01" \
+                  --query "functionKeys.default" -o tsv)
+
+                if [ -z "$functionKey" ] || [ "$functionKey" = "null" ]; then
+                  echo "Onboarding Function App key was not returned."
+                  exit 1
+                fi
+
+                echo "##vso[task.setvariable variable=ONBOARDING_API_BASE_URL]https://$(onboardingFunctionAppName).azurewebsites.net"
+                echo "##vso[task.setvariable variable=ONBOARDING_FUNCTION_KEY;issecret=true]$functionKey"
+
+          - script: npm run build
+            workingDirectory: adom8-onboarding/src/web
+            displayName: Build onboarding UI
+            env:
+              NEXT_PUBLIC_ONBOARDING_API_BASE_URL: $(ONBOARDING_API_BASE_URL)
+              NEXT_PUBLIC_ONBOARDING_FUNCTION_KEY: $(ONBOARDING_FUNCTION_KEY)
+
+          - task: AzureCLI@2
+            displayName: Fetch Static Web App deployment token
+            inputs:
+              azureSubscription: $(azureServiceConnection)
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                token=$(az staticwebapp secrets list \
+                  --name $(onboardingStaticWebAppName) \
+                  --resource-group $(sharedResourceGroupName) \
+                  --query "properties.apiKey" -o tsv)
+
+                if [ -z "$token" ] || [ "$token" = "null" ]; then
+                  echo "Static Web App deployment token was not returned."
+                  exit 1
+                fi
+
+                echo "##vso[task.setvariable variable=STATIC_WEB_APP_API_TOKEN;issecret=true]$token"
+
           - task: AzureStaticWebApp@0
             inputs:
-              app_location: src/web
-              output_location: out
+              azure_static_web_apps_api_token: $(STATIC_WEB_APP_API_TOKEN)
+              app_location: adom8-onboarding/src/web
+              output_location: .next

--- a/adom8-onboarding/README.md
+++ b/adom8-onboarding/README.md
@@ -1,23 +1,38 @@
 # ADOm8 Managed Onboarding (Control Plane)
 
-This folder scaffolds a **parallel managed onboarding path** that provisions project-isolated ADOm8 deployments from a shared control plane.
+This folder contains the optional **portfolio onboarding control plane** for organizations that want to onboard multiple ADOm8 projects into one shared Azure subscription without forking ADOm8 for every project.
 
 ## What is included
 
 - Durable Function registration API + status endpoint
 - Provisioning orchestrator and activity contracts
 - Model and service contracts for onboarding lifecycle
-- Bicep templates (`infra/shared.bicep`, `infra/project.bicep`)
+- Bicep templates (`infra/shared.bicep`, `infra/project.bicep`) for the shared control plane and per-project runtime resources
 - Starter Next.js onboarding UI pages/components
 - Shared deployment pipeline (`.ado/pipelines/deploy-shared.yml`)
 
 ## Design goals
 
-- No modifications to existing ADOm8 orchestration path in this repository
+- Keep the public "fork ADOm8 and run the onboarding pipeline" path intact
+- Reuse the existing ADOm8 runtime (`src/AIAgents.*`), dashboard, and setup/provisioning behavior instead of creating a second agent engine
 - Zero-clone GitHub operations (REST API only)
 - Managed identity-first Azure SDK usage
 - Idempotent provisioning stages
 
 ## Notes
 
-This is an implementation scaffold intended to be iterated in a dedicated `toddpick/adom8-onboarding` repo.
+This control plane should remain optional. It is meant for portfolio/shared-subscription deployments; single-project self-hosted users can keep using `adom8-onboarding-pipeline.yml`.
+
+## Local checks
+
+```bash
+dotnet build adom8-onboarding/src/Functions/adom8-onboarding.csproj
+az bicep build --file adom8-onboarding/infra/shared.bicep
+az bicep build --file adom8-onboarding/infra/project.bicep
+cd adom8-onboarding/src/web && npm ci && npm run build
+```
+
+The starter web app calls the onboarding Functions API using:
+
+- `NEXT_PUBLIC_ONBOARDING_API_BASE_URL` - onboarding Function App base URL
+- `NEXT_PUBLIC_ONBOARDING_FUNCTION_KEY` - temporary POC function key until Entra/SWA auth is added

--- a/adom8-onboarding/README.md
+++ b/adom8-onboarding/README.md
@@ -1,0 +1,23 @@
+# ADOm8 Managed Onboarding (Control Plane)
+
+This folder scaffolds a **parallel managed onboarding path** that provisions project-isolated ADOm8 deployments from a shared control plane.
+
+## What is included
+
+- Durable Function registration API + status endpoint
+- Provisioning orchestrator and activity contracts
+- Model and service contracts for onboarding lifecycle
+- Bicep templates (`infra/shared.bicep`, `infra/project.bicep`)
+- Starter Next.js onboarding UI pages/components
+- Shared deployment pipeline (`.ado/pipelines/deploy-shared.yml`)
+
+## Design goals
+
+- No modifications to existing ADOm8 orchestration path in this repository
+- Zero-clone GitHub operations (REST API only)
+- Managed identity-first Azure SDK usage
+- Idempotent provisioning stages
+
+## Notes
+
+This is an implementation scaffold intended to be iterated in a dedicated `toddpick/adom8-onboarding` repo.

--- a/adom8-onboarding/infra/project.bicep
+++ b/adom8-onboarding/infra/project.bicep
@@ -1,5 +1,8 @@
+targetScope = 'subscription'
+
 param projectId string
 param location string = 'westus2'
+param sharedResourceGroupName string = 'rg-adom8-shared'
 param sharedKeyVaultName string = 'kv-adom8-shared'
 param sharedServiceBusNamespace string = 'sb-adom8-shared'
 
@@ -22,3 +25,19 @@ module projectResources './project.resources.bicep' = {
     location: location
   }
 }
+
+module projectMessaging './project.messaging.bicep' = {
+  name: 'adom8-project-messaging-${projectId}'
+  scope: resourceGroup(sharedResourceGroupName)
+  params: {
+    projectId: projectId
+    sharedKeyVaultName: sharedKeyVaultName
+    sharedServiceBusNamespace: sharedServiceBusNamespace
+    projectFunctionPrincipalId: projectResources.outputs.functionPrincipalId
+  }
+}
+
+output resourceGroupName string = rg.name
+output functionAppName string = projectResources.outputs.functionAppName
+output storageAccountName string = projectResources.outputs.storageAccountName
+output serviceBusTopicName string = projectMessaging.outputs.serviceBusTopicName

--- a/adom8-onboarding/infra/project.bicep
+++ b/adom8-onboarding/infra/project.bicep
@@ -1,0 +1,24 @@
+param projectId string
+param location string = 'westus2'
+param sharedKeyVaultName string = 'kv-adom8-shared'
+param sharedServiceBusNamespace string = 'sb-adom8-shared'
+
+var resourceGroupName = 'rg-adom8-${projectId}'
+var functionAppName = 'fa-adom8-${projectId}'
+
+resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+module projectResources './project.resources.bicep' = {
+  name: 'adom8-project-${projectId}'
+  scope: rg
+  params: {
+    projectId: projectId
+    functionAppName: functionAppName
+    sharedKeyVaultName: sharedKeyVaultName
+    sharedServiceBusNamespace: sharedServiceBusNamespace
+    location: location
+  }
+}

--- a/adom8-onboarding/infra/project.messaging.bicep
+++ b/adom8-onboarding/infra/project.messaging.bicep
@@ -1,0 +1,46 @@
+param projectId string
+param sharedKeyVaultName string
+param sharedServiceBusNamespace string
+param projectFunctionPrincipalId string
+
+var keyVaultSecretsUserRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')
+var serviceBusDataOwnerRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '090c5cfd-751d-490a-894a-3ce6f1109419')
+
+resource sharedKeyVault 'Microsoft.KeyVault/vaults@2023-02-01' existing = {
+  name: sharedKeyVaultName
+}
+
+resource serviceBus 'Microsoft.ServiceBus/namespaces@2022-10-01-preview' existing = {
+  name: sharedServiceBusNamespace
+}
+
+resource selfHealingTopic 'Microsoft.ServiceBus/namespaces/topics@2022-10-01-preview' = {
+  parent: serviceBus
+  name: 'adom8-${projectId}'
+  properties: {
+    defaultMessageTimeToLive: 'P14D'
+    enablePartitioning: true
+  }
+}
+
+resource projectKeyVaultSecretsUser 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(sharedKeyVault.id, projectId, keyVaultSecretsUserRoleDefinitionId)
+  scope: sharedKeyVault
+  properties: {
+    roleDefinitionId: keyVaultSecretsUserRoleDefinitionId
+    principalId: projectFunctionPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource projectServiceBusDataOwner 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(selfHealingTopic.id, projectId, serviceBusDataOwnerRoleDefinitionId)
+  scope: selfHealingTopic
+  properties: {
+    roleDefinitionId: serviceBusDataOwnerRoleDefinitionId
+    principalId: projectFunctionPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output serviceBusTopicName string = selfHealingTopic.name

--- a/adom8-onboarding/infra/project.resources.bicep
+++ b/adom8-onboarding/infra/project.resources.bicep
@@ -4,13 +4,36 @@ param sharedKeyVaultName string
 param sharedServiceBusNamespace string
 param location string = 'westus2'
 
+var storageName = take('stadom8${replace(toLower(projectId), '-', '')}${uniqueString(resourceGroup().id)}', 24)
+var sharedKeyVaultUrl = 'https://${sharedKeyVaultName}.vault.${environment().suffixes.keyvaultDns}'
+var serviceBusTopicName = 'adom8-${projectId}'
+
 resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
-  name: 'stadom8${take(replace(projectId, '-', ''), 15)}${uniqueString(resourceGroup().id)}'
+  name: storageName
   location: location
   sku: {
     name: 'Standard_LRS'
   }
   kind: 'StorageV2'
+}
+
+resource agentTasksQueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2023-05-01' = {
+  name: '${storage.name}/default/agent-tasks'
+}
+
+resource poisonQueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2023-05-01' = {
+  name: '${storage.name}/default/agent-tasks-poison'
+}
+
+resource activityLogTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' = {
+  name: '${storage.name}/default/activitylog'
+}
+
+resource tempReposContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  name: '${storage.name}/default/temp-repos'
+  properties: {
+    publicAccess: 'None'
+  }
 }
 
 resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
@@ -27,10 +50,26 @@ resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
   name: functionAppName
   location: location
   kind: 'functionapp'
+  identity: {
+    type: 'SystemAssigned'
+  }
   properties: {
+    httpsOnly: true
     serverFarmId: appServicePlan.id
     siteConfig: {
       appSettings: [
+        {
+          name: 'AzureWebJobsStorage'
+          value: 'DefaultEndpointsProtocol=https;AccountName=${storage.name};AccountKey=${storage.listKeys().keys[0].value};EndpointSuffix=${environment().suffixes.storage}'
+        }
+        {
+          name: 'FUNCTIONS_EXTENSION_VERSION'
+          value: '~4'
+        }
+        {
+          name: 'FUNCTIONS_WORKER_RUNTIME'
+          value: 'dotnet-isolated'
+        }
         {
           name: 'ADOM8_PROJECT_ID'
           value: projectId
@@ -40,10 +79,22 @@ resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
           value: sharedKeyVaultName
         }
         {
+          name: 'Onboarding__SharedKeyVaultUrl'
+          value: sharedKeyVaultUrl
+        }
+        {
           name: 'Onboarding__SharedServiceBusNamespace'
           value: sharedServiceBusNamespace
+        }
+        {
+          name: 'Onboarding__SelfHealingTopicName'
+          value: serviceBusTopicName
         }
       ]
     }
   }
 }
+
+output functionAppName string = functionApp.name
+output functionPrincipalId string = functionApp.identity.principalId
+output storageAccountName string = storage.name

--- a/adom8-onboarding/infra/project.resources.bicep
+++ b/adom8-onboarding/infra/project.resources.bicep
@@ -1,0 +1,49 @@
+param projectId string
+param functionAppName string
+param sharedKeyVaultName string
+param sharedServiceBusNamespace string
+param location string = 'westus2'
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: 'stadom8${take(replace(projectId, '-', ''), 15)}${uniqueString(resourceGroup().id)}'
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: 'asp-${projectId}'
+  location: location
+  sku: {
+    name: 'Y1'
+    tier: 'Dynamic'
+  }
+  kind: 'functionapp'
+}
+
+resource functionApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: functionAppName
+  location: location
+  kind: 'functionapp'
+  properties: {
+    serverFarmId: appServicePlan.id
+    siteConfig: {
+      appSettings: [
+        {
+          name: 'ADOM8_PROJECT_ID'
+          value: projectId
+        }
+        {
+          name: 'Onboarding__SharedKeyVaultName'
+          value: sharedKeyVaultName
+        }
+        {
+          name: 'Onboarding__SharedServiceBusNamespace'
+          value: sharedServiceBusNamespace
+        }
+      ]
+    }
+  }
+}

--- a/adom8-onboarding/infra/shared.bicep
+++ b/adom8-onboarding/infra/shared.bicep
@@ -1,0 +1,15 @@
+param resourceGroupName string = 'rg-adom8-shared'
+param location string = 'westus2'
+
+resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
+  name: resourceGroupName
+  location: location
+}
+
+module sharedResources './shared.resources.bicep' = {
+  name: 'adom8-shared-resources'
+  scope: rg
+  params: {
+    location: location
+  }
+}

--- a/adom8-onboarding/infra/shared.bicep
+++ b/adom8-onboarding/infra/shared.bicep
@@ -1,5 +1,11 @@
+targetScope = 'subscription'
+
 param resourceGroupName string = 'rg-adom8-shared'
 param location string = 'westus2'
+param onboardingFunctionAppName string = 'fa-adom8-registration'
+param onboardingStaticWebAppName string = 'stapp-adom8-onboarding'
+param sharedKeyVaultName string = 'kv-adom8-shared'
+param sharedServiceBusNamespace string = 'sb-adom8-shared'
 
 resource rg 'Microsoft.Resources/resourceGroups@2023-07-01' = {
   name: resourceGroupName
@@ -11,5 +17,16 @@ module sharedResources './shared.resources.bicep' = {
   scope: rg
   params: {
     location: location
+    onboardingFunctionAppName: onboardingFunctionAppName
+    onboardingStaticWebAppName: onboardingStaticWebAppName
+    sharedKeyVaultName: sharedKeyVaultName
+    sharedServiceBusNamespace: sharedServiceBusNamespace
   }
 }
+
+output resourceGroupName string = rg.name
+output onboardingFunctionAppName string = sharedResources.outputs.onboardingFunctionAppName
+output onboardingStaticWebAppName string = sharedResources.outputs.onboardingStaticWebAppName
+output sharedKeyVaultName string = sharedResources.outputs.sharedKeyVaultName
+output sharedKeyVaultUrl string = sharedResources.outputs.sharedKeyVaultUrl
+output sharedServiceBusNamespace string = sharedResources.outputs.sharedServiceBusNamespace

--- a/adom8-onboarding/infra/shared.resources.bicep
+++ b/adom8-onboarding/infra/shared.resources.bicep
@@ -1,0 +1,23 @@
+param location string = 'westus2'
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: 'stadom8registry${uniqueString(resourceGroup().id)}'
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-02-01' = {
+  name: 'kv-adom8-shared'
+  location: location
+  properties: {
+    tenantId: tenant().tenantId
+    sku: {
+      name: 'standard'
+      family: 'A'
+    }
+    enableRbacAuthorization: true
+  }
+}

--- a/adom8-onboarding/infra/shared.resources.bicep
+++ b/adom8-onboarding/infra/shared.resources.bicep
@@ -1,7 +1,15 @@
 param location string = 'westus2'
+param onboardingFunctionAppName string = 'fa-adom8-registration'
+param onboardingStaticWebAppName string = 'stapp-adom8-onboarding'
+param sharedKeyVaultName string = 'kv-adom8-shared'
+param sharedServiceBusNamespace string = 'sb-adom8-shared'
+
+var storageName = take('stadom8reg${uniqueString(resourceGroup().id)}', 24)
+var sharedKeyVaultUrl = 'https://${sharedKeyVaultName}.vault.${environment().suffixes.keyvaultDns}'
+var keyVaultSecretsOfficerRoleDefinitionId = subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')
 
 resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
-  name: 'stadom8registry${uniqueString(resourceGroup().id)}'
+  name: storageName
   location: location
   sku: {
     name: 'Standard_LRS'
@@ -10,7 +18,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
 }
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-02-01' = {
-  name: 'kv-adom8-shared'
+  name: sharedKeyVaultName
   location: location
   properties: {
     tenantId: tenant().tenantId
@@ -21,3 +29,89 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-02-01' = {
     enableRbacAuthorization: true
   }
 }
+
+resource serviceBus 'Microsoft.ServiceBus/namespaces@2022-10-01-preview' = {
+  name: sharedServiceBusNamespace
+  location: location
+  sku: {
+    name: 'Standard'
+    tier: 'Standard'
+  }
+}
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2023-12-01' = {
+  name: 'asp-adom8-onboarding'
+  location: location
+  sku: {
+    name: 'Y1'
+    tier: 'Dynamic'
+  }
+  kind: 'functionapp'
+}
+
+resource onboardingFunctionApp 'Microsoft.Web/sites@2023-12-01' = {
+  name: onboardingFunctionAppName
+  location: location
+  kind: 'functionapp'
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    httpsOnly: true
+    serverFarmId: appServicePlan.id
+    siteConfig: {
+      appSettings: [
+        {
+          name: 'AzureWebJobsStorage'
+          value: 'DefaultEndpointsProtocol=https;AccountName=${storage.name};AccountKey=${storage.listKeys().keys[0].value};EndpointSuffix=${environment().suffixes.storage}'
+        }
+        {
+          name: 'FUNCTIONS_EXTENSION_VERSION'
+          value: '~4'
+        }
+        {
+          name: 'FUNCTIONS_WORKER_RUNTIME'
+          value: 'dotnet-isolated'
+        }
+        {
+          name: 'Onboarding__SharedKeyVaultName'
+          value: keyVault.name
+        }
+        {
+          name: 'Onboarding__SharedKeyVaultUrl'
+          value: sharedKeyVaultUrl
+        }
+        {
+          name: 'Onboarding__SharedServiceBusNamespace'
+          value: serviceBus.name
+        }
+      ]
+    }
+  }
+}
+
+resource onboardingKeyVaultSecretsOfficer 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, onboardingFunctionApp.name, keyVaultSecretsOfficerRoleDefinitionId)
+  scope: keyVault
+  properties: {
+    roleDefinitionId: keyVaultSecretsOfficerRoleDefinitionId
+    principalId: onboardingFunctionApp.identity.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource onboardingStaticWebApp 'Microsoft.Web/staticSites@2023-12-01' = {
+  name: onboardingStaticWebAppName
+  location: location
+  sku: {
+    name: 'Free'
+    tier: 'Free'
+  }
+  properties: {}
+}
+
+output onboardingFunctionAppName string = onboardingFunctionApp.name
+output onboardingStaticWebAppName string = onboardingStaticWebApp.name
+output sharedKeyVaultName string = keyVault.name
+output sharedKeyVaultUrl string = sharedKeyVaultUrl
+output sharedServiceBusNamespace string = serviceBus.name

--- a/adom8-onboarding/src/Activities/ConfigureAdoActivity.cs
+++ b/adom8-onboarding/src/Activities/ConfigureAdoActivity.cs
@@ -1,0 +1,14 @@
+using ADOm8.Onboarding.Models;
+using Microsoft.Azure.Functions.Worker;
+
+namespace ADOm8.Onboarding.Activities;
+
+public sealed class ConfigureAdoActivity
+{
+    [Function("ConfigureAdo")]
+    public Task<AdoResult> Run([ActivityTrigger] ProvisioningInput input)
+    {
+        // Stub for idempotent webhook registration/custom field creation.
+        return Task.FromResult(new AdoResult(input.Request.AdoProject, WebhooksRegistered: true, InitiativeAreaPath: input.Request.AdoProject));
+    }
+}

--- a/adom8-onboarding/src/Activities/CreateInitStoryActivity.cs
+++ b/adom8-onboarding/src/Activities/CreateInitStoryActivity.cs
@@ -1,0 +1,17 @@
+using ADOm8.Onboarding.Models;
+using Microsoft.Azure.Functions.Worker;
+
+namespace ADOm8.Onboarding.Activities;
+
+public sealed class CreateInitStoryActivity
+{
+    [Function("CreateInitStory")]
+    public Task<StoryResult> Run([ActivityTrigger] ProvisioningInput input)
+    {
+        var storyId = 1042;
+        var storyUrl = $"{input.Request.AdoOrg}/{input.Request.AdoProject}/_workitems/edit/{storyId}";
+        var agentTabUrl = $"{input.Request.GithubRepo}/pulls?q=is:open+label:copilot";
+
+        return Task.FromResult(new StoryResult(storyId, storyUrl, agentTabUrl));
+    }
+}

--- a/adom8-onboarding/src/Activities/FinalizeRegistrationActivity.cs
+++ b/adom8-onboarding/src/Activities/FinalizeRegistrationActivity.cs
@@ -1,0 +1,22 @@
+using ADOm8.Onboarding.Models;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace ADOm8.Onboarding.Activities;
+
+public sealed class FinalizeRegistrationActivity
+{
+    private readonly ILogger<FinalizeRegistrationActivity> _logger;
+
+    public FinalizeRegistrationActivity(ILogger<FinalizeRegistrationActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    [Function("FinalizeRegistration")]
+    public Task Run([ActivityTrigger] FinalizeInput input)
+    {
+        _logger.LogInformation("Finalize registration for {ProjectId}", input.Input.ProjectId);
+        return Task.CompletedTask;
+    }
+}

--- a/adom8-onboarding/src/Activities/GenerateCodebaseContextActivity.cs
+++ b/adom8-onboarding/src/Activities/GenerateCodebaseContextActivity.cs
@@ -1,0 +1,22 @@
+using ADOm8.Onboarding.Models;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace ADOm8.Onboarding.Activities;
+
+public sealed class GenerateCodebaseContextActivity
+{
+    private readonly ILogger<GenerateCodebaseContextActivity> _logger;
+
+    public GenerateCodebaseContextActivity(ILogger<GenerateCodebaseContextActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    [Function("GenerateCodebaseContext")]
+    public Task Run([ActivityTrigger] ProvisioningInput input)
+    {
+        _logger.LogInformation("CODEBASE_CONTEXT generation requested for {ProjectId} using GitHub REST APIs only.", input.ProjectId);
+        return Task.CompletedTask;
+    }
+}

--- a/adom8-onboarding/src/Activities/ProvisionInfrastructureActivity.cs
+++ b/adom8-onboarding/src/Activities/ProvisionInfrastructureActivity.cs
@@ -1,0 +1,28 @@
+using ADOm8.Onboarding.Models;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+
+namespace ADOm8.Onboarding.Activities;
+
+public sealed class ProvisionInfrastructureActivity
+{
+    private readonly ILogger<ProvisionInfrastructureActivity> _logger;
+
+    public ProvisionInfrastructureActivity(ILogger<ProvisionInfrastructureActivity> logger)
+    {
+        _logger = logger;
+    }
+
+    [Function("ProvisionInfrastructure")]
+    public Task<InfraResult> Run([ActivityTrigger] ProvisioningInput input)
+    {
+        // Stub for ARM/Bicep deployment via managed identity.
+        _logger.LogInformation("ProvisionInfrastructure requested for {ProjectId}", input.ProjectId);
+
+        return Task.FromResult(new InfraResult(
+            $"rg-adom8-{input.ProjectId}",
+            $"fa-adom8-{input.ProjectId}",
+            $"https://dashboard.adom8.dev/{input.ProjectId}",
+            $"adom8-{input.ProjectId}"));
+    }
+}

--- a/adom8-onboarding/src/Activities/StoreSecretsActivity.cs
+++ b/adom8-onboarding/src/Activities/StoreSecretsActivity.cs
@@ -1,0 +1,30 @@
+using System.Text.Json;
+using ADOm8.Onboarding.Models;
+using ADOm8.Onboarding.Services;
+using Microsoft.Azure.Functions.Worker;
+
+namespace ADOm8.Onboarding.Activities;
+
+public sealed class StoreSecretsActivity
+{
+    private readonly IKeyVaultService _keyVaultService;
+
+    public StoreSecretsActivity(IKeyVaultService keyVaultService)
+    {
+        _keyVaultService = keyVaultService;
+    }
+
+    [Function("StoreSecrets")]
+    public async Task Run([ActivityTrigger] ProvisioningInput input)
+    {
+        var prefix = input.ProjectId;
+        await _keyVaultService.SetSecretAsync($"{prefix}-ado-pat", input.Request.AdoPat);
+        await _keyVaultService.SetSecretAsync($"{prefix}-github-pat", input.Request.GithubPat);
+        await _keyVaultService.SetSecretAsync($"{prefix}-config", JsonSerializer.Serialize(input.Request));
+
+        if (input.Request.Capabilities.SelfHealing && !string.IsNullOrWhiteSpace(input.Request.Capabilities.SelfHealingConnectionString))
+        {
+            await _keyVaultService.SetSecretAsync($"{prefix}-sb-connection", input.Request.Capabilities.SelfHealingConnectionString);
+        }
+    }
+}

--- a/adom8-onboarding/src/Activities/ValidateCredentialsActivity.cs
+++ b/adom8-onboarding/src/Activities/ValidateCredentialsActivity.cs
@@ -1,0 +1,24 @@
+using ADOm8.Onboarding.Models;
+using ADOm8.Onboarding.Services;
+using Microsoft.Azure.Functions.Worker;
+
+namespace ADOm8.Onboarding.Activities;
+
+public sealed class ValidateCredentialsActivity
+{
+    private readonly IAdoService _adoService;
+    private readonly IGitHubService _gitHubService;
+
+    public ValidateCredentialsActivity(IAdoService adoService, IGitHubService gitHubService)
+    {
+        _adoService = adoService;
+        _gitHubService = gitHubService;
+    }
+
+    [Function("ValidateCredentials")]
+    public async Task Run([ActivityTrigger] ProvisioningInput input)
+    {
+        await _adoService.ValidateProjectAccessAsync(input.Request.AdoOrg, input.Request.AdoProject, input.Request.AdoPat);
+        await _gitHubService.ValidateRepositoryAccessAsync(input.Request.GithubRepo, input.Request.GithubPat, input.Request.PrimaryBranch);
+    }
+}

--- a/adom8-onboarding/src/Functions/Program.cs
+++ b/adom8-onboarding/src/Functions/Program.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 var host = new HostBuilder()
-    .ConfigureFunctionsWebApplication()
+    .ConfigureFunctionsWorkerDefaults()
     .ConfigureServices(services =>
     {
         services.AddHttpClient();

--- a/adom8-onboarding/src/Functions/Program.cs
+++ b/adom8-onboarding/src/Functions/Program.cs
@@ -1,0 +1,17 @@
+using ADOm8.Onboarding.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+var host = new HostBuilder()
+    .ConfigureFunctionsWebApplication()
+    .ConfigureServices(services =>
+    {
+        services.AddHttpClient();
+        services.AddSingleton<IProjectIdService, ProjectIdService>();
+        services.AddSingleton<IKeyVaultService, KeyVaultService>();
+        services.AddSingleton<IAdoService, AdoService>();
+        services.AddSingleton<IGitHubService, GitHubService>();
+    })
+    .Build();
+
+host.Run();

--- a/adom8-onboarding/src/Functions/RegistrationFunction.cs
+++ b/adom8-onboarding/src/Functions/RegistrationFunction.cs
@@ -4,6 +4,7 @@ using ADOm8.Onboarding.Models;
 using ADOm8.Onboarding.Services;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask;
 using Microsoft.DurableTask.Client;
 
 namespace ADOm8.Onboarding.Functions;
@@ -19,14 +20,33 @@ public sealed class RegistrationFunction
 
     [Function("RegisterProject")]
     public async Task<HttpResponseData> Register(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "projects/register")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "projects/register")] HttpRequestData req,
         [DurableClient] DurableTaskClient client)
     {
-        var body = await JsonSerializer.DeserializeAsync<ProjectRegistrationRequest>(req.Body);
+        ProjectRegistrationRequest? body;
+        try
+        {
+            body = await JsonSerializer.DeserializeAsync<ProjectRegistrationRequest>(
+                req.Body,
+                new JsonSerializerOptions(JsonSerializerDefaults.Web));
+        }
+        catch (JsonException)
+        {
+            body = null;
+        }
+
         if (body is null)
         {
             var bad = req.CreateResponse(HttpStatusCode.BadRequest);
             await bad.WriteStringAsync("Invalid request body.");
+            return bad;
+        }
+
+        var validationErrors = Validate(body).ToArray();
+        if (validationErrors.Length > 0)
+        {
+            var bad = req.CreateResponse(HttpStatusCode.BadRequest);
+            await bad.WriteAsJsonAsync(new { errors = validationErrors });
             return bad;
         }
 
@@ -35,8 +55,8 @@ public sealed class RegistrationFunction
 
         await client.ScheduleNewOrchestrationInstanceAsync(
             "ProvisioningOrchestrator",
-            provisioningId,
-            new ProvisioningInput(provisioningId, projectId, body));
+            new ProvisioningInput(provisioningId, projectId, body),
+            new StartOrchestrationOptions { InstanceId = provisioningId });
 
         var response = req.CreateResponse(HttpStatusCode.Accepted);
         await response.WriteAsJsonAsync(new
@@ -47,5 +67,16 @@ public sealed class RegistrationFunction
         });
 
         return response;
+    }
+
+    private static IEnumerable<string> Validate(ProjectRegistrationRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.DisplayName)) yield return "displayName is required.";
+        if (string.IsNullOrWhiteSpace(request.AdoOrg)) yield return "adoOrg is required.";
+        if (string.IsNullOrWhiteSpace(request.AdoProject)) yield return "adoProject is required.";
+        if (string.IsNullOrWhiteSpace(request.AdoPat)) yield return "adoPat is required.";
+        if (string.IsNullOrWhiteSpace(request.GithubRepo)) yield return "githubRepo is required.";
+        if (string.IsNullOrWhiteSpace(request.GithubPat)) yield return "githubPat is required.";
+        if (request.DefaultAutonomyLevel is < 1 or > 5) yield return "defaultAutonomyLevel must be between 1 and 5.";
     }
 }

--- a/adom8-onboarding/src/Functions/RegistrationFunction.cs
+++ b/adom8-onboarding/src/Functions/RegistrationFunction.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using System.Text.Json;
+using ADOm8.Onboarding.Models;
+using ADOm8.Onboarding.Services;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask.Client;
+
+namespace ADOm8.Onboarding.Functions;
+
+public sealed class RegistrationFunction
+{
+    private readonly IProjectIdService _projectIdService;
+
+    public RegistrationFunction(IProjectIdService projectIdService)
+    {
+        _projectIdService = projectIdService;
+    }
+
+    [Function("RegisterProject")]
+    public async Task<HttpResponseData> Register(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "projects/register")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client)
+    {
+        var body = await JsonSerializer.DeserializeAsync<ProjectRegistrationRequest>(req.Body);
+        if (body is null)
+        {
+            var bad = req.CreateResponse(HttpStatusCode.BadRequest);
+            await bad.WriteStringAsync("Invalid request body.");
+            return bad;
+        }
+
+        var projectId = _projectIdService.GenerateProjectId(body.AdoOrg, body.AdoProject);
+        var provisioningId = Guid.NewGuid().ToString("N");
+
+        await client.ScheduleNewOrchestrationInstanceAsync(
+            "ProvisioningOrchestrator",
+            provisioningId,
+            new ProvisioningInput(provisioningId, projectId, body));
+
+        var response = req.CreateResponse(HttpStatusCode.Accepted);
+        await response.WriteAsJsonAsync(new
+        {
+            provisioningId,
+            statusUrl = $"/projects/{provisioningId}/status",
+            projectId
+        });
+
+        return response;
+    }
+}

--- a/adom8-onboarding/src/Functions/StatusFunction.cs
+++ b/adom8-onboarding/src/Functions/StatusFunction.cs
@@ -1,0 +1,40 @@
+using System.Net;
+using ADOm8.Onboarding.Models;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.DurableTask.Client;
+
+namespace ADOm8.Onboarding.Functions;
+
+public sealed class StatusFunction
+{
+    [Function("GetProvisioningStatus")]
+    public async Task<HttpResponseData> GetStatus(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "projects/{provisioningId}/status")] HttpRequestData req,
+        [DurableClient] DurableTaskClient client,
+        string provisioningId)
+    {
+        var metadata = await client.GetInstanceAsync(provisioningId);
+        var status = new ProvisioningStatus
+        {
+            ProvisioningId = provisioningId,
+            Stage = metadata?.RuntimeStatus.ToString() ?? "not-found",
+            ProgressPercent = metadata is null ? 0 : ResolveProgress(metadata.RuntimeStatus.ToString()),
+            RuntimeStatus = metadata?.RuntimeStatus.ToString() ?? "not-found"
+        };
+
+        var response = req.CreateResponse(metadata is null ? HttpStatusCode.NotFound : HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(status);
+        return response;
+    }
+
+    private static int ResolveProgress(string? status)
+        => status switch
+        {
+            "Completed" => 100,
+            "Running" => 45,
+            "Pending" => 10,
+            "Failed" => 100,
+            _ => 0
+        };
+}

--- a/adom8-onboarding/src/Functions/StatusFunction.cs
+++ b/adom8-onboarding/src/Functions/StatusFunction.cs
@@ -10,7 +10,7 @@ public sealed class StatusFunction
 {
     [Function("GetProvisioningStatus")]
     public async Task<HttpResponseData> GetStatus(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "projects/{provisioningId}/status")] HttpRequestData req,
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "projects/{provisioningId}/status")] HttpRequestData req,
         [DurableClient] DurableTaskClient client,
         string provisioningId)
     {

--- a/adom8-onboarding/src/Functions/adom8-onboarding.csproj
+++ b/adom8-onboarding/src/Functions/adom8-onboarding.csproj
@@ -8,6 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Activities\**\*.cs" LinkBase="Activities" />
+    <Compile Include="..\Models\**\*.cs" LinkBase="Models" />
+    <Compile Include="..\Orchestrators\**\*.cs" LinkBase="Orchestrators" />
+    <Compile Include="..\Services\**\*.cs" LinkBase="Services" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />

--- a/adom8-onboarding/src/Functions/adom8-onboarding.csproj
+++ b/adom8-onboarding/src/Functions/adom8-onboarding.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.0" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.DurableTask" Version="1.3.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+    <PackageReference Include="Azure.Data.Tables" Version="12.9.1" />
+    <PackageReference Include="Azure.ResourceManager" Version="1.13.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
+  </ItemGroup>
+</Project>

--- a/adom8-onboarding/src/Models/ProjectRegistration.cs
+++ b/adom8-onboarding/src/Models/ProjectRegistration.cs
@@ -1,0 +1,23 @@
+namespace ADOm8.Onboarding.Models;
+
+public sealed record ProvisionedInfo(string ResourceGroup, string FunctionAppName, string DashboardUrl, string ServiceBusTopic);
+public sealed record AdoRegistrationInfo(int InitStoryId, string InitStoryUrl, bool WebhooksRegistered);
+public sealed record GithubRegistrationInfo(string AgentTabUrl, string? InitPrUrl);
+
+public sealed record ProjectRegistration
+{
+    public required string ProjectId { get; init; }
+    public required string DisplayName { get; init; }
+    public required string Status { get; init; }
+    public required string AdoOrg { get; init; }
+    public required string AdoProject { get; init; }
+    public required string GithubRepo { get; init; }
+    public required string PrimaryBranch { get; init; }
+    public int DefaultAutonomyLevel { get; init; } = 3;
+    public CapabilityOptions Capabilities { get; init; } = new();
+    public ProvisionedInfo? Provisioned { get; init; }
+    public AdoRegistrationInfo? Ado { get; init; }
+    public GithubRegistrationInfo? Github { get; init; }
+    public DateTimeOffset RegisteredAt { get; init; }
+    public DateTimeOffset? ProvisioningCompletedAt { get; init; }
+}

--- a/adom8-onboarding/src/Models/ProjectRegistrationRequest.cs
+++ b/adom8-onboarding/src/Models/ProjectRegistrationRequest.cs
@@ -1,0 +1,21 @@
+namespace ADOm8.Onboarding.Models;
+
+public sealed record CapabilityOptions
+{
+    public bool SelfHealing { get; init; }
+    public string? SelfHealingConnectionString { get; init; }
+    public bool PlaywrightTesting { get; init; }
+}
+
+public sealed record ProjectRegistrationRequest
+{
+    public required string DisplayName { get; init; }
+    public required string AdoOrg { get; init; }
+    public required string AdoProject { get; init; }
+    public required string AdoPat { get; init; }
+    public required string GithubRepo { get; init; }
+    public required string GithubPat { get; init; }
+    public string PrimaryBranch { get; init; } = "main";
+    public int DefaultAutonomyLevel { get; init; } = 3;
+    public CapabilityOptions Capabilities { get; init; } = new();
+}

--- a/adom8-onboarding/src/Models/ProvisioningStatus.cs
+++ b/adom8-onboarding/src/Models/ProvisioningStatus.cs
@@ -1,0 +1,13 @@
+namespace ADOm8.Onboarding.Models;
+
+public sealed record LiveLinks(string? DashboardUrl, string? AgentTabUrl, string? InitStoryUrl);
+
+public sealed record ProvisioningStatus
+{
+    public required string ProvisioningId { get; init; }
+    public required string Stage { get; init; }
+    public int ProgressPercent { get; init; }
+    public required string RuntimeStatus { get; init; }
+    public string? Error { get; init; }
+    public LiveLinks Links { get; init; } = new(null, null, null);
+}

--- a/adom8-onboarding/src/Models/StoryResult.cs
+++ b/adom8-onboarding/src/Models/StoryResult.cs
@@ -1,0 +1,8 @@
+namespace ADOm8.Onboarding.Models;
+
+public sealed record StoryResult(int StoryId, string StoryUrl, string AgentTabUrl);
+public sealed record AdoResult(string ProjectId, bool WebhooksRegistered, string InitiativeAreaPath);
+public sealed record InfraResult(string ResourceGroupName, string FunctionAppName, string DashboardUrl, string ServiceBusTopic);
+
+public sealed record ProvisioningInput(string ProvisioningId, string ProjectId, ProjectRegistrationRequest Request);
+public sealed record FinalizeInput(ProvisioningInput Input, InfraResult Infra, AdoResult Ado, StoryResult Story);

--- a/adom8-onboarding/src/Orchestrators/ProvisioningOrchestrator.cs
+++ b/adom8-onboarding/src/Orchestrators/ProvisioningOrchestrator.cs
@@ -1,0 +1,26 @@
+using ADOm8.Onboarding.Models;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.DurableTask;
+
+namespace ADOm8.Onboarding.Orchestrators;
+
+public sealed class ProvisioningOrchestrator
+{
+    [Function("ProvisioningOrchestrator")]
+    public async Task RunOrchestrator([OrchestrationTrigger] TaskOrchestrationContext context)
+    {
+        var input = context.GetInput<ProvisioningInput>()
+            ?? throw new InvalidOperationException("Provisioning input is required.");
+
+        var retry = TaskOptions.FromRetryPolicy(new RetryPolicy(3, TimeSpan.FromSeconds(5)));
+
+        await context.CallActivityAsync("ValidateCredentials", input, retry);
+        await context.CallActivityAsync("StoreSecrets", input, retry);
+        var infraResult = await context.CallActivityAsync<InfraResult>("ProvisionInfrastructure", input, retry);
+        var adoResult = await context.CallActivityAsync<AdoResult>("ConfigureAdo", input, retry);
+        await context.CallActivityAsync("GenerateCodebaseContext", input, retry);
+        var storyResult = await context.CallActivityAsync<StoryResult>("CreateInitStory", input, retry);
+
+        await context.CallActivityAsync("FinalizeRegistration", new FinalizeInput(input, infraResult, adoResult, storyResult), retry);
+    }
+}

--- a/adom8-onboarding/src/Services/AdoService.cs
+++ b/adom8-onboarding/src/Services/AdoService.cs
@@ -1,0 +1,30 @@
+namespace ADOm8.Onboarding.Services;
+
+public interface IAdoService
+{
+    Task ValidateProjectAccessAsync(string adoOrg, string adoProject, string pat, CancellationToken cancellationToken = default);
+}
+
+public sealed class AdoService : IAdoService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public AdoService(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task ValidateProjectAccessAsync(string adoOrg, string adoProject, string pat, CancellationToken cancellationToken = default)
+    {
+        var client = _httpClientFactory.CreateClient();
+        var token = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes($":{pat}"));
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{adoOrg}/_apis/projects/{adoProject}?api-version=7.1-preview.4");
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", token);
+
+        var response = await client.SendAsync(request, cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"ADO project validation failed with {(int)response.StatusCode}.");
+        }
+    }
+}

--- a/adom8-onboarding/src/Services/AdoService.cs
+++ b/adom8-onboarding/src/Services/AdoService.cs
@@ -18,7 +18,9 @@ public sealed class AdoService : IAdoService
     {
         var client = _httpClientFactory.CreateClient();
         var token = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes($":{pat}"));
-        using var request = new HttpRequestMessage(HttpMethod.Get, $"{adoOrg}/_apis/projects/{adoProject}?api-version=7.1-preview.4");
+        var organizationUrl = NormalizeOrganizationUrl(adoOrg);
+        var projectSegment = Uri.EscapeDataString(adoProject);
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{organizationUrl}/_apis/projects/{projectSegment}?api-version=7.1-preview.4");
         request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", token);
 
         var response = await client.SendAsync(request, cancellationToken);
@@ -26,5 +28,16 @@ public sealed class AdoService : IAdoService
         {
             throw new InvalidOperationException($"ADO project validation failed with {(int)response.StatusCode}.");
         }
+    }
+
+    private static string NormalizeOrganizationUrl(string adoOrg)
+    {
+        var trimmed = adoOrg.Trim().TrimEnd('/');
+        if (Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+        {
+            return uri.GetLeftPart(UriPartial.Path).TrimEnd('/');
+        }
+
+        return $"https://dev.azure.com/{trimmed}";
     }
 }

--- a/adom8-onboarding/src/Services/GitHubService.cs
+++ b/adom8-onboarding/src/Services/GitHubService.cs
@@ -36,9 +36,18 @@ public sealed class GitHubService : IGitHubService
 
     private static (string owner, string repo) ParseRepo(string repoUrl)
     {
-        var uri = new Uri(repoUrl);
-        var parts = uri.AbsolutePath.Trim('/').Split('/');
+        string path;
+        if (Uri.TryCreate(repoUrl, UriKind.Absolute, out var uri))
+        {
+            path = uri.AbsolutePath;
+        }
+        else
+        {
+            path = repoUrl;
+        }
+
+        var parts = path.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length < 2) throw new ArgumentException("Invalid GitHub repository URL.");
-        return (parts[0], parts[1]);
+        return (parts[0], parts[1].EndsWith(".git", StringComparison.OrdinalIgnoreCase) ? parts[1][..^4] : parts[1]);
     }
 }

--- a/adom8-onboarding/src/Services/GitHubService.cs
+++ b/adom8-onboarding/src/Services/GitHubService.cs
@@ -1,0 +1,44 @@
+namespace ADOm8.Onboarding.Services;
+
+public interface IGitHubService
+{
+    Task ValidateRepositoryAccessAsync(string repoUrl, string pat, string branch, CancellationToken cancellationToken = default);
+}
+
+public sealed class GitHubService : IGitHubService
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+
+    public GitHubService(IHttpClientFactory httpClientFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+    }
+
+    public async Task ValidateRepositoryAccessAsync(string repoUrl, string pat, string branch, CancellationToken cancellationToken = default)
+    {
+        var (owner, repo) = ParseRepo(repoUrl);
+        var client = _httpClientFactory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", pat);
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("adom8-onboarding");
+
+        var repoResponse = await client.GetAsync($"https://api.github.com/repos/{owner}/{repo}", cancellationToken);
+        if (!repoResponse.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"GitHub repository validation failed with {(int)repoResponse.StatusCode}.");
+        }
+
+        var branchResponse = await client.GetAsync($"https://api.github.com/repos/{owner}/{repo}/branches/{branch}", cancellationToken);
+        if (!branchResponse.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException($"GitHub branch validation failed with {(int)branchResponse.StatusCode}.");
+        }
+    }
+
+    private static (string owner, string repo) ParseRepo(string repoUrl)
+    {
+        var uri = new Uri(repoUrl);
+        var parts = uri.AbsolutePath.Trim('/').Split('/');
+        if (parts.Length < 2) throw new ArgumentException("Invalid GitHub repository URL.");
+        return (parts[0], parts[1]);
+    }
+}

--- a/adom8-onboarding/src/Services/KeyVaultService.cs
+++ b/adom8-onboarding/src/Services/KeyVaultService.cs
@@ -1,0 +1,24 @@
+using Azure.Identity;
+using Azure.Security.KeyVault.Secrets;
+
+namespace ADOm8.Onboarding.Services;
+
+public interface IKeyVaultService
+{
+    Task SetSecretAsync(string name, string value, CancellationToken cancellationToken = default);
+}
+
+public sealed class KeyVaultService : IKeyVaultService
+{
+    private readonly SecretClient _secretClient;
+
+    public KeyVaultService(IConfiguration configuration)
+    {
+        var keyVaultUrl = configuration["Onboarding:SharedKeyVaultUrl"]
+            ?? throw new InvalidOperationException("Onboarding:SharedKeyVaultUrl is required.");
+        _secretClient = new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
+    }
+
+    public async Task SetSecretAsync(string name, string value, CancellationToken cancellationToken = default)
+        => await _secretClient.SetSecretAsync(name, value, cancellationToken);
+}

--- a/adom8-onboarding/src/Services/KeyVaultService.cs
+++ b/adom8-onboarding/src/Services/KeyVaultService.cs
@@ -1,5 +1,6 @@
 using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
+using Microsoft.Extensions.Configuration;
 
 namespace ADOm8.Onboarding.Services;
 
@@ -15,10 +16,20 @@ public sealed class KeyVaultService : IKeyVaultService
     public KeyVaultService(IConfiguration configuration)
     {
         var keyVaultUrl = configuration["Onboarding:SharedKeyVaultUrl"]
-            ?? throw new InvalidOperationException("Onboarding:SharedKeyVaultUrl is required.");
+            ?? BuildVaultUrl(configuration["Onboarding:SharedKeyVaultName"]);
         _secretClient = new SecretClient(new Uri(keyVaultUrl), new DefaultAzureCredential());
     }
 
     public async Task SetSecretAsync(string name, string value, CancellationToken cancellationToken = default)
         => await _secretClient.SetSecretAsync(name, value, cancellationToken);
+
+    private static string BuildVaultUrl(string? vaultName)
+    {
+        if (string.IsNullOrWhiteSpace(vaultName))
+        {
+            throw new InvalidOperationException("Onboarding:SharedKeyVaultUrl or Onboarding:SharedKeyVaultName is required.");
+        }
+
+        return $"https://{vaultName}.vault.azure.net/";
+    }
 }

--- a/adom8-onboarding/src/Services/ProjectIdService.cs
+++ b/adom8-onboarding/src/Services/ProjectIdService.cs
@@ -1,0 +1,40 @@
+using System.Text.RegularExpressions;
+
+namespace ADOm8.Onboarding.Services;
+
+public interface IProjectIdService
+{
+    string GenerateProjectId(string adoOrg, string adoProject);
+}
+
+public sealed class ProjectIdService : IProjectIdService
+{
+    private static readonly Regex InvalidChars = new("[^a-z0-9-]", RegexOptions.Compiled);
+    private static readonly Regex MultiDash = new("-+", RegexOptions.Compiled);
+
+    public string GenerateProjectId(string adoOrg, string adoProject)
+    {
+        var orgSlug = Slugify(adoOrg.Replace("https://dev.azure.com/", string.Empty, StringComparison.OrdinalIgnoreCase));
+        var projectSlug = Slugify(adoProject);
+        var candidate = $"{projectSlug}-{orgSlug}".Trim('-');
+
+        if (candidate.Length > 50)
+        {
+            candidate = candidate[..50].Trim('-');
+        }
+
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            throw new ArgumentException("Unable to derive valid projectId from inputs.");
+        }
+
+        return candidate;
+    }
+
+    private static string Slugify(string value)
+    {
+        var lowered = value.ToLowerInvariant().Trim().Replace(' ', '-');
+        var cleaned = InvalidChars.Replace(lowered, "-");
+        return MultiDash.Replace(cleaned, "-").Trim('-');
+    }
+}

--- a/adom8-onboarding/src/web/app/dashboard/[projectId]/page.tsx
+++ b/adom8-onboarding/src/web/app/dashboard/[projectId]/page.tsx
@@ -1,0 +1,15 @@
+import { LiveLinks } from '../../../components/LiveLinks';
+
+export default function DashboardPage({ params }: { params: { projectId: string } }) {
+  return (
+    <main className="mx-auto max-w-5xl p-8">
+      <h1 className="text-2xl font-semibold">Project Dashboard</h1>
+      <p className="mt-2 text-sm text-gray-600">Project ID: {params.projectId}</p>
+      <LiveLinks
+        agentTabUrl="#"
+        initStoryUrl="#"
+        dashboardUrl={`https://dashboard.adom8.dev/${params.projectId}`}
+      />
+    </main>
+  );
+}

--- a/adom8-onboarding/src/web/app/globals.css
+++ b/adom8-onboarding/src/web/app/globals.css
@@ -1,0 +1,23 @@
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+}
+
+input,
+button {
+  font: inherit;
+}
+
+a {
+  color: inherit;
+}

--- a/adom8-onboarding/src/web/app/layout.tsx
+++ b/adom8-onboarding/src/web/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'ADOm8 Onboarding',
+  description: 'Portfolio onboarding control plane for ADOm8 projects'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/adom8-onboarding/src/web/app/onboard/page.tsx
+++ b/adom8-onboarding/src/web/app/onboard/page.tsx
@@ -1,0 +1,11 @@
+import { OnboardingForm } from '../../components/OnboardingForm';
+
+export default function OnboardPage() {
+  return (
+    <main className="mx-auto max-w-4xl p-8">
+      <h1 className="text-2xl font-semibold">ADOm8 Managed Onboarding</h1>
+      <p className="mt-2 text-sm text-gray-600">Register an ADO project + GitHub repo for managed ADOm8 provisioning.</p>
+      <OnboardingForm />
+    </main>
+  );
+}

--- a/adom8-onboarding/src/web/app/onboard/status/[provisioningId]/page.tsx
+++ b/adom8-onboarding/src/web/app/onboard/status/[provisioningId]/page.tsx
@@ -1,0 +1,10 @@
+import { ProvisioningProgress } from '../../../../components/ProvisioningProgress';
+
+export default function OnboardStatusPage({ params }: { params: { provisioningId: string } }) {
+  return (
+    <main className="mx-auto max-w-4xl p-8">
+      <h1 className="text-2xl font-semibold">Provisioning Status</h1>
+      <ProvisioningProgress provisioningId={params.provisioningId} />
+    </main>
+  );
+}

--- a/adom8-onboarding/src/web/components/LiveLinks.tsx
+++ b/adom8-onboarding/src/web/components/LiveLinks.tsx
@@ -1,0 +1,20 @@
+export function LiveLinks({
+  dashboardUrl,
+  initStoryUrl,
+  agentTabUrl
+}: {
+  dashboardUrl: string;
+  initStoryUrl: string;
+  agentTabUrl: string;
+}) {
+  return (
+    <section className="mt-6 rounded border p-4">
+      <h2 className="font-medium">Live Links</h2>
+      <ul className="mt-2 list-disc pl-6 text-sm">
+        <li><a className="text-blue-600" href={agentTabUrl}>GitHub Copilot Agent Tab</a></li>
+        <li><a className="text-blue-600" href={initStoryUrl}>ADO Init Story</a></li>
+        <li><a className="text-blue-600" href={dashboardUrl}>Project Dashboard</a></li>
+      </ul>
+    </section>
+  );
+}

--- a/adom8-onboarding/src/web/components/OnboardingForm.tsx
+++ b/adom8-onboarding/src/web/components/OnboardingForm.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+export function OnboardingForm() {
+  return (
+    <form className="mt-6 grid gap-4">
+      <input className="rounded border p-2" placeholder="ADO Organization URL" />
+      <input className="rounded border p-2" placeholder="ADO Project Name" />
+      <input className="rounded border p-2" placeholder="ADO PAT" type="password" />
+      <input className="rounded border p-2" placeholder="GitHub Repository URL" />
+      <input className="rounded border p-2" placeholder="GitHub PAT" type="password" />
+      <button className="rounded bg-black px-4 py-2 text-white" type="submit">Start Onboarding</button>
+    </form>
+  );
+}

--- a/adom8-onboarding/src/web/components/OnboardingForm.tsx
+++ b/adom8-onboarding/src/web/components/OnboardingForm.tsx
@@ -1,14 +1,72 @@
 'use client';
 
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { registerProject } from '../lib/onboardingApi';
+
 export function OnboardingForm() {
+  const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    const form = new FormData(event.currentTarget);
+    try {
+      const result = await registerProject({
+        displayName: String(form.get('displayName') ?? ''),
+        adoOrg: String(form.get('adoOrg') ?? ''),
+        adoProject: String(form.get('adoProject') ?? ''),
+        adoPat: String(form.get('adoPat') ?? ''),
+        githubRepo: String(form.get('githubRepo') ?? ''),
+        githubPat: String(form.get('githubPat') ?? ''),
+        primaryBranch: String(form.get('primaryBranch') ?? 'main') || 'main',
+        defaultAutonomyLevel: Number(form.get('defaultAutonomyLevel') ?? 3),
+        capabilities: {
+          selfHealing: form.get('selfHealing') === 'on',
+          playwrightTesting: form.get('playwrightTesting') === 'on'
+        }
+      });
+
+      router.push(`/onboard/status/${result.provisioningId}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Registration failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
   return (
-    <form className="mt-6 grid gap-4">
-      <input className="rounded border p-2" placeholder="ADO Organization URL" />
-      <input className="rounded border p-2" placeholder="ADO Project Name" />
-      <input className="rounded border p-2" placeholder="ADO PAT" type="password" />
-      <input className="rounded border p-2" placeholder="GitHub Repository URL" />
-      <input className="rounded border p-2" placeholder="GitHub PAT" type="password" />
-      <button className="rounded bg-black px-4 py-2 text-white" type="submit">Start Onboarding</button>
+    <form className="mt-6 grid gap-4" onSubmit={handleSubmit}>
+      <input className="rounded border p-2" name="displayName" placeholder="Display Name" required />
+      <input className="rounded border p-2" name="adoOrg" placeholder="ADO Organization URL or name" required />
+      <input className="rounded border p-2" name="adoProject" placeholder="ADO Project Name" required />
+      <input className="rounded border p-2" name="adoPat" placeholder="ADO PAT" type="password" required />
+      <input className="rounded border p-2" name="githubRepo" placeholder="GitHub Repository URL or owner/repo" required />
+      <input className="rounded border p-2" name="githubPat" placeholder="GitHub PAT" type="password" required />
+      <input className="rounded border p-2" name="primaryBranch" placeholder="Primary branch" defaultValue="main" />
+      <select className="rounded border p-2" name="defaultAutonomyLevel" defaultValue="3">
+        <option value="1">Autonomy 1 - Plan only</option>
+        <option value="2">Autonomy 2 - Code only</option>
+        <option value="3">Autonomy 3 - Review and pause</option>
+        <option value="4">Autonomy 4 - Auto-merge</option>
+        <option value="5">Autonomy 5 - Full autonomy</option>
+      </select>
+      <label className="flex items-center gap-2 text-sm">
+        <input name="selfHealing" type="checkbox" defaultChecked />
+        Enable shared self-healing topic
+      </label>
+      <label className="flex items-center gap-2 text-sm">
+        <input name="playwrightTesting" type="checkbox" />
+        Enable Playwright test setup
+      </label>
+      {error && <p className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p>}
+      <button className="rounded bg-black px-4 py-2 text-white disabled:opacity-60" type="submit" disabled={submitting}>
+        {submitting ? 'Starting...' : 'Start Onboarding'}
+      </button>
     </form>
   );
 }

--- a/adom8-onboarding/src/web/components/ProvisioningProgress.tsx
+++ b/adom8-onboarding/src/web/components/ProvisioningProgress.tsx
@@ -1,9 +1,47 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+import { getProvisioningStatus, type ProvisioningStatus } from '../lib/onboardingApi';
+
 export function ProvisioningProgress({ provisioningId }: { provisioningId: string }) {
+  const [status, setStatus] = useState<ProvisioningStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      try {
+        const nextStatus = await getProvisioningStatus(provisioningId);
+        if (!cancelled) {
+          setStatus(nextStatus);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Unable to load provisioning status.');
+        }
+      }
+    }
+
+    load();
+    const timer = window.setInterval(load, 5000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [provisioningId]);
+
+  const progress = status?.progressPercent ?? 0;
+
   return (
     <section className="mt-6 rounded border p-4">
       <p className="text-sm text-gray-600">Provisioning ID: {provisioningId}</p>
+      <div className="mt-4 h-3 overflow-hidden rounded bg-gray-200">
+        <div className="h-full bg-black transition-all" style={{ width: `${progress}%` }} />
+      </div>
+      <p className="mt-2 text-sm">Status: {status?.runtimeStatus ?? 'Loading...'}</p>
+      {error && <p className="mt-2 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{error}</p>}
       <ul className="mt-3 list-disc pl-6 text-sm">
         <li>Credentials validation</li>
         <li>Secret storage</li>

--- a/adom8-onboarding/src/web/components/ProvisioningProgress.tsx
+++ b/adom8-onboarding/src/web/components/ProvisioningProgress.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+export function ProvisioningProgress({ provisioningId }: { provisioningId: string }) {
+  return (
+    <section className="mt-6 rounded border p-4">
+      <p className="text-sm text-gray-600">Provisioning ID: {provisioningId}</p>
+      <ul className="mt-3 list-disc pl-6 text-sm">
+        <li>Credentials validation</li>
+        <li>Secret storage</li>
+        <li>Infrastructure deployment</li>
+        <li>ADO configuration</li>
+        <li>Codebase context + init story</li>
+      </ul>
+    </section>
+  );
+}

--- a/adom8-onboarding/src/web/lib/onboardingApi.ts
+++ b/adom8-onboarding/src/web/lib/onboardingApi.ts
@@ -1,0 +1,83 @@
+const apiBaseUrl = process.env.NEXT_PUBLIC_ONBOARDING_API_BASE_URL ?? '';
+const functionKey = process.env.NEXT_PUBLIC_ONBOARDING_FUNCTION_KEY ?? '';
+
+export interface ProjectRegistrationPayload {
+  displayName: string;
+  adoOrg: string;
+  adoProject: string;
+  adoPat: string;
+  githubRepo: string;
+  githubPat: string;
+  primaryBranch: string;
+  defaultAutonomyLevel: number;
+  capabilities: {
+    selfHealing: boolean;
+    playwrightTesting: boolean;
+  };
+}
+
+export interface RegistrationResponse {
+  provisioningId: string;
+  statusUrl: string;
+  projectId: string;
+}
+
+export interface ProvisioningStatus {
+  provisioningId: string;
+  stage: string;
+  progressPercent: number;
+  runtimeStatus: string;
+  error?: string;
+}
+
+function buildApiUrl(path: string) {
+  const base = apiBaseUrl || window.location.origin;
+  const url = new URL(`/api/${path.replace(/^\/+/, '')}`, base);
+  if (functionKey) {
+    url.searchParams.set('code', functionKey);
+  }
+
+  return url;
+}
+
+export async function registerProject(payload: ProjectRegistrationPayload): Promise<RegistrationResponse> {
+  const response = await fetch(buildApiUrl('projects/register'), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    throw new Error(await readError(response));
+  }
+
+  return response.json();
+}
+
+export async function getProvisioningStatus(provisioningId: string): Promise<ProvisioningStatus> {
+  const response = await fetch(buildApiUrl(`projects/${provisioningId}/status`), {
+    cache: 'no-store'
+  });
+
+  if (!response.ok) {
+    throw new Error(await readError(response));
+  }
+
+  return response.json();
+}
+
+async function readError(response: Response) {
+  const text = await response.text();
+  if (!text) {
+    return `Request failed with HTTP ${response.status}`;
+  }
+
+  try {
+    const body = JSON.parse(text);
+    return body.error ?? body.errors?.join?.(' ') ?? text;
+  } catch {
+    return text;
+  }
+}

--- a/adom8-onboarding/src/web/next-env.d.ts
+++ b/adom8-onboarding/src/web/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/adom8-onboarding/src/web/package-lock.json
+++ b/adom8-onboarding/src/web/package-lock.json
@@ -1,0 +1,976 @@
+{
+  "name": "adom8-onboarding-web",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "adom8-onboarding-web",
+      "version": "0.1.0",
+      "dependencies": {
+        "next": "16.2.4",
+        "react": "19.2.5",
+        "react-dom": "19.2.5"
+      },
+      "devDependencies": {
+        "@types/node": "20.17.24",
+        "@types/react": "19.2.14",
+        "@types/react-dom": "19.2.3",
+        "typescript": "5.8.2"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
+      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
+      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
+      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.17.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.24.tgz",
+      "integrity": "sha512-d7fGCyB96w9BnWQrOsJtpyiSaBcAYYr75bnK6ZRjDbql2cGLj/3GsL5OYmLPNq76l7Gf2q4Rv9J2o6h5CrD9sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.22",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.22.tgz",
+      "integrity": "sha512-6qruVrb5rse6WylFkU0FhBKKGuecWseqdpQfhkawn6ztyk2QlfwSRjsDxMCLJrkfmfN21qvhl9ABgaMeRkuwww==",
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
+      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "16.2.4",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.4",
+        "@next/swc-darwin-x64": "16.2.4",
+        "@next/swc-linux-arm64-gnu": "16.2.4",
+        "@next/swc-linux-arm64-musl": "16.2.4",
+        "@next/swc-linux-x64-gnu": "16.2.4",
+        "@next/swc-linux-x64-musl": "16.2.4",
+        "@next/swc-win32-arm64-msvc": "16.2.4",
+        "@next/swc-win32-x64-msvc": "16.2.4",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/adom8-onboarding/src/web/package.json
+++ b/adom8-onboarding/src/web/package.json
@@ -8,8 +8,17 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "14.2.5",
-    "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "next": "16.2.4",
+    "react": "19.2.5",
+    "react-dom": "19.2.5"
+  },
+  "overrides": {
+    "postcss": "8.5.10"
+  },
+  "devDependencies": {
+    "@types/node": "20.17.24",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
+    "typescript": "5.8.2"
   }
 }

--- a/adom8-onboarding/src/web/package.json
+++ b/adom8-onboarding/src/web/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "adom8-onboarding-web",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  }
+}

--- a/adom8-onboarding/src/web/tsconfig.json
+++ b/adom8-onboarding/src/web/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "target": "ES2017"
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a parallel managed onboarding control plane to provision per-project ADOm8 deployments without modifying the existing orchestrator code.
- Enable org-shared Azure subscription deployments now and a SaaS multi-tenant path in the future with a single minimal form-driven registration flow.
- Keep backward compatibility with the canonical `toddpick/adom8` runtime by scoping all onboarding changes to a new `adom8-onboarding/` scaffold.

### Description
- Add a new `adom8-onboarding/` scaffold containing Azure Functions (registration + status), a Durable Functions orchestrator, activity function boundaries, models, and service abstractions for project-id generation, ADO/GitHub validation, and Key Vault secret storage.
- Add Bicep templates (`infra/shared.bicep`, `infra/project.bicep`, supporting modules) that provision shared resources and per-project resources and explicitly set the `ADOM8_PROJECT_ID` app setting on per-project Function Apps to enable namespaced secret resolution.
- Add activity stubs that implement the onboarding stages (`ValidateCredentials`, `StoreSecrets`, `ProvisionInfrastructure`, `ConfigureAdo`, `GenerateCodebaseContext`, `CreateInitStory`, `FinalizeRegistration`) and an orchestrator with a retry policy wiring them together.
- Add a starter Next.js onboarding UI (`src/web/`) with registration, provisioning status and dashboard pages plus a shared deployment pipeline at `.ado/pipelines/deploy-shared.yml` to deploy shared infra, the Registration API, and the Static Web App.

### Testing
- An attempt to build the Functions project with `dotnet build adom8-onboarding/src/Functions/adom8-onboarding.csproj` was executed and failed in this environment because `dotnet` is not available in the runner (build failure).
- No automated unit/integration tests were executed in this environment; CI should run `dotnet build` and unit tests and validate the ARM/Bicep deployments and Durable Function end-to-end in an environment with `dotnet` and Azure credentials available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1c53a6e48321acf0e97ca9e1e5c8)